### PR TITLE
#bug fix UpdateUser API, #Improvement TemporaryPWGeneration, API Filter

### DIFF
--- a/internal/helper/password.go
+++ b/internal/helper/password.go
@@ -1,14 +1,10 @@
 package helper
 
 import (
+	"crypto/rand"
 	"golang.org/x/crypto/bcrypt"
-	"math/rand"
-	"time"
+	"math/big"
 )
-
-func init() {
-	rand.NewSource(time.Now().UnixNano())
-}
 
 func HashPassword(password string) (string, error) {
 	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
@@ -28,8 +24,15 @@ func GenerateRandomString(length int) string {
 	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 	b := make([]rune, length)
 	for i := range b {
-		num := rand.Intn(len(letters))
-		b[i] = letters[num]
+		b[i] = randomRune(letters)
 	}
 	return string(b)
+}
+
+func randomRune(chars []rune) rune {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
+	if err != nil {
+		panic(err)
+	}
+	return chars[n.Int64()]
 }

--- a/internal/helper/password_test.go
+++ b/internal/helper/password_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestPasswordGeneration(t *testing.T) {
+func TestPasswordHashing(t *testing.T) {
 	password := "admin"
 	hashedPassword, err := helper.HashPassword(password)
 	fmt.Println(hashedPassword)
@@ -18,4 +18,19 @@ func TestPasswordGeneration(t *testing.T) {
 		t.Errorf("CheckPasswordHash() error")
 		return
 	}
+}
+
+func TestPasswordGeneration(t *testing.T) {
+	length := 8
+	sameCount := 0
+	for i := 0; i < 10000000; i++ {
+		firstGenPassword := helper.GenerateRandomString(length)
+		secondGenPassword := helper.GenerateRandomString(length)
+		if firstGenPassword == secondGenPassword {
+			fmt.Printf("Index: %d. It's same %s\n", i, firstGenPassword)
+			sameCount++
+		}
+	}
+	fmt.Println("Same count: ", sameCount)
+	fmt.Println("Same ratio: ", float64(sameCount)/100000)
 }

--- a/internal/keycloak/keycloak.go
+++ b/internal/keycloak/keycloak.go
@@ -29,7 +29,6 @@ type IKeycloak interface {
 	GetUsers(organizationId string) ([]*gocloak.User, error)
 	DeleteUser(organizationId string, userAccountId string) error
 	UpdateUser(organizationId string, user *gocloak.User) error
-	GetGroup(organizationId string, groupName string) (*gocloak.Group, error)
 	JoinGroup(organizationId string, userId string, groupName string) error
 	LeaveGroup(organizationId string, userId string, groupName string) error
 
@@ -438,20 +437,6 @@ func (k *Keycloak) Logout(sessionId string, organizationId string) error {
 		return err
 	}
 	return nil
-}
-
-func (k *Keycloak) GetGroup(organizationId string, groupName string) (*gocloak.Group, error) {
-	ctx := context.Background()
-	token, err := k.loginAdmin(ctx)
-	if err != nil {
-		log.Error(err)
-		return nil, err
-	}
-	groups, err := k.client.GetGroups(ctx, token.AccessToken, organizationId, gocloak.GetGroupsParams{
-		Search: &groupName,
-	})
-
-	return groups[0], nil
 }
 
 func (k *Keycloak) JoinGroup(organizationId string, userId string, groupName string) error {

--- a/internal/keycloak/keycloak.go
+++ b/internal/keycloak/keycloak.go
@@ -29,6 +29,9 @@ type IKeycloak interface {
 	GetUsers(organizationId string) ([]*gocloak.User, error)
 	DeleteUser(organizationId string, userAccountId string) error
 	UpdateUser(organizationId string, user *gocloak.User) error
+	GetGroup(organizationId string, groupName string) (*gocloak.Group, error)
+	JoinGroup(organizationId string, userId string, groupName string) error
+	LeaveGroup(organizationId string, userId string, groupName string) error
 
 	VerifyAccessToken(token string, organizationId string) error
 	GetSessions(userId string, organizationId string) (*[]string, error)
@@ -433,6 +436,68 @@ func (k *Keycloak) Logout(sessionId string, organizationId string) error {
 	err = k.client.LogoutUserSession(ctx, token.AccessToken, organizationId, sessionId)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func (k *Keycloak) GetGroup(organizationId string, groupName string) (*gocloak.Group, error) {
+	ctx := context.Background()
+	token, err := k.loginAdmin(ctx)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+	groups, err := k.client.GetGroups(ctx, token.AccessToken, organizationId, gocloak.GetGroupsParams{
+		Search: &groupName,
+	})
+
+	return groups[0], nil
+}
+
+func (k *Keycloak) JoinGroup(organizationId string, userId string, groupName string) error {
+	ctx := context.Background()
+	token, err := k.loginAdmin(ctx)
+	if err != nil {
+		log.Error(err)
+		return httpErrors.NewInternalServerError(fmt.Errorf("internal server error"))
+	}
+	groups, err := k.client.GetGroups(ctx, token.AccessToken, organizationId, gocloak.GetGroupsParams{
+		Search: &groupName,
+	})
+	if err != nil {
+		log.Error(err)
+		return httpErrors.NewInternalServerError(err)
+	}
+	if len(groups) == 0 {
+		return httpErrors.NewNotFoundError(fmt.Errorf("group not found"))
+	}
+	if err := k.client.AddUserToGroup(ctx, token.AccessToken, organizationId, userId, *groups[0].ID); err != nil {
+		log.Error(err)
+		return httpErrors.NewInternalServerError(err)
+	}
+	return nil
+}
+
+func (k *Keycloak) LeaveGroup(organizationId string, userId string, groupName string) error {
+	ctx := context.Background()
+	token, err := k.loginAdmin(ctx)
+	if err != nil {
+		log.Error(err)
+		return httpErrors.NewInternalServerError(fmt.Errorf("internal server error"))
+	}
+	groups, err := k.client.GetGroups(ctx, token.AccessToken, organizationId, gocloak.GetGroupsParams{
+		Search: &groupName,
+	})
+	if err != nil {
+		log.Error(err)
+		return httpErrors.NewInternalServerError(err)
+	}
+	if len(groups) == 0 {
+		return httpErrors.NewNotFoundError(fmt.Errorf("group not found"))
+	}
+	if err := k.client.DeleteUserFromGroup(ctx, token.AccessToken, organizationId, userId, *groups[0].ID); err != nil {
+		log.Error(err)
+		return httpErrors.NewInternalServerError(err)
 	}
 	return nil
 }

--- a/internal/middleware/auth/authorizer/password.go
+++ b/internal/middleware/auth/authorizer/password.go
@@ -30,9 +30,10 @@ func PasswordFilter(handler http.Handler, repo repository.Repository) http.Handl
 			return
 		}
 		if helper.IsDurationExpired(storedUser.PasswordUpdatedAt, internal.PasswordExpiredDuration) {
-			allowedUrl := [2]string{
+			allowedUrl := []string{
 				internal.API_PREFIX + internal.API_VERSION + "/organizations/" + requestUserInfo.GetOrganizationId() + "/my-profile" + "/password",
 				internal.API_PREFIX + internal.API_VERSION + "/organizations/" + requestUserInfo.GetOrganizationId() + "/my-profile" + "/next-password-change",
+				internal.API_PREFIX + internal.API_VERSION + "/auth/logout",
 			}
 			if !(urlContains(allowedUrl, r.URL.Path) && r.Method == http.MethodPut) {
 				internalHttp.ErrorJSON(w, httpErrors.NewForbiddenError(fmt.Errorf("password expired")))
@@ -43,7 +44,7 @@ func PasswordFilter(handler http.Handler, repo repository.Repository) http.Handl
 	})
 }
 
-func urlContains(urls [2]string, url string) bool {
+func urlContains(urls []string, url string) bool {
 	for _, u := range urls {
 		if u == url {
 			return true

--- a/internal/usecase/user.go
+++ b/internal/usecase/user.go
@@ -544,14 +544,15 @@ func (u *UserUsecase) UpdateByAccountIdByAdmin(ctx context.Context, accountId st
 	} else if len(*users) > 1 {
 		return nil, fmt.Errorf("multiple users found")
 	}
-
 	if user.Role.Name != (*users)[0].Role.Name {
-		groups := []string{fmt.Sprintf("%s@%s", user.Role.Name, userInfo.GetOrganizationId())}
-		if err := u.kc.UpdateUser(userInfo.GetOrganizationId(), &gocloak.User{
-			ID:     &(*users)[0].ID,
-			Groups: &groups,
-		}); err != nil {
-			log.Errorf("updating user in keycloak failed: %v", err)
+		originGroupName := fmt.Sprintf("%s@%s", (*users)[0].Role.Name, userInfo.GetOrganizationId())
+		newGroupName := fmt.Sprintf("%s@%s", user.Role.Name, userInfo.GetOrganizationId())
+		if err := u.kc.LeaveGroup(userInfo.GetOrganizationId(), (*users)[0].ID, originGroupName); err != nil {
+			log.Errorf("leave group in keycloak failed: %v", err)
+			return nil, httpErrors.NewInternalServerError(err)
+		}
+		if err := u.kc.JoinGroup(userInfo.GetOrganizationId(), (*users)[0].ID, newGroupName); err != nil {
+			log.Errorf("join group in keycloak failed: %v", err)
 			return nil, httpErrors.NewInternalServerError(err)
 		}
 	}

--- a/pkg/domain/mapper_test.go
+++ b/pkg/domain/mapper_test.go
@@ -55,7 +55,7 @@ func TestConvert(t *testing.T) {
 					Description: "test",
 					Phone:       "test",
 					Status:      OrganizationStatus_CREATE,
-					Status:      "good",
+					StatusDesc:  "good",
 					Creator:     "",
 					CreatedAt:   time.Time{},
 					UpdatedAt:   time.Time{},


### PR DESCRIPTION
Bug fix:
- 내용: UpdateUserAPI 를 통해 user의 role을 변경이 Keycloak에 정상적으로 반영되지 않음
- 원인: keycloak의 UpdateUser API만으로는 의도하는 동작 불가능
- 변경사항: JoinGroup&LeaveGroup 방식으로 구현방식 수정 

Improve:
- 임시 비밀번호 생성 로직 개선
  - 임시 비밀번호 생성에 있어서 동일한 PW 발급되는 현상 리포트
  - 임시 비밀번호 생성 로직에서 "math/rand"를 사용하는 것 보다 "crypto/rand"를 사용하는 것이 더욱 secure하다는 권고 확인
  - "crypto/rand"를 사용하여 생성하도록 로직 수정
- PW가 만료된 사용자에게 logout API 접근 허용 추가
  - PasswordFilter 로직에 허용 로직 추가