### PR TITLE
0517 alpha test 수정사항 반영

### DIFF
--- a/internal/usecase/user.go
+++ b/internal/usecase/user.go
@@ -524,7 +524,7 @@ func (u *UserUsecase) UpdateByAccountIdByAdmin(ctx context.Context, accountId st
 	if err != nil {
 		return nil, err
 	}
-	if *originUser.Email != user.Email {
+	if originUser.Email == nil || *originUser.Email != user.Email {
 		originUser.Email = gocloak.StringP(user.Email)
 		err = u.kc.UpdateUser(userInfo.GetOrganizationId(), originUser)
 		if err != nil {

--- a/pkg/domain/organization.go
+++ b/pkg/domain/organization.go
@@ -62,7 +62,7 @@ type Organization = struct {
 }
 
 type CreateOrganizationRequest struct {
-	Name        string `json:"name" validate:"required,min=3,max=20"`
+	Name        string `json:"name" validate:"required,min=1,max=30"`
 	Description string `json:"description" validate:"omitempty,min=0,max=100"`
 	Phone       string `json:"phone"`
 }
@@ -101,7 +101,7 @@ type ListOrganizationBody struct {
 
 type UpdateOrganizationRequest struct {
 	PrimaryClusterId string `json:"primaryClusterId"`
-	Name             string `json:"name" validate:"required,min=3,max=20"`
+	Name             string `json:"name" validate:"required,min=1,max=30"`
 	Description      string `json:"description" validate:"omitempty,min=0,max=100"`
 	Phone            string `json:"phone"`
 }

--- a/pkg/domain/user.go
+++ b/pkg/domain/user.go
@@ -51,9 +51,9 @@ type Policy = struct {
 type CreateUserRequest struct {
 	AccountId   string `json:"accountId" validate:"required"`
 	Password    string `json:"password" validate:"required"`
-	Name        string `json:"name" validate:"min=0,max=20"`
+	Name        string `json:"name" validate:"min=1,max=30"`
 	Email       string `json:"email" validate:"required,email"`
-	Department  string `json:"department" validate:"min=0,max=20"`
+	Department  string `json:"department" validate:"min=0,max=50"`
 	Role        string `json:"role" validate:"required,oneof=admin user"`
 	Description string `json:"description" validate:"min=0,max=100"`
 }
@@ -111,10 +111,10 @@ type ListUserBody struct {
 }
 
 type UpdateUserRequest struct {
-	Name        string `json:"name" validate:"omitempty,min=0,max=20"`
+	Name        string `json:"name" validate:"omitempty,min=1,max=30"`
 	Role        string `json:"role" validate:"oneof=admin user"`
 	Email       string `json:"email" validate:"omitempty,email"`
-	Department  string `json:"department" validate:"omitempty,min=0,max=20"`
+	Department  string `json:"department" validate:"omitempty,min=0,max=50"`
 	Description string `json:"description" validate:"omitempty,min=0,max=100"`
 }
 
@@ -146,9 +146,9 @@ type GetMyProfileResponse struct {
 }
 type UpdateMyProfileRequest struct {
 	Password   string `json:"password" validate:"required"`
-	Name       string `json:"name" validate:"omitempty,min=0,max=20"`
+	Name       string `json:"name" validate:"omitempty,min=1,max=30"`
 	Email      string `json:"email" validate:"omitempty,email"`
-	Department string `json:"department" validate:"omitempty,min=0,max=20"`
+	Department string `json:"department" validate:"omitempty,min=0,max=50"`
 }
 
 type UpdateMyProfileResponse struct {


### PR DESCRIPTION
UpdateByAccountIdByAdmin
- NPE 문제 발생
- 원인: 
  - Organization 생성 시 admin 계정을 자동으로 만들며 email은 넣지 않은 채로 생성
  - 이로 인해 비교 구문에서 NPE 발생
- 해결:
  - NPE 발생 구문 변경 및 빈 값에 대한 업데이트 가능하도록 수정

Field Length 관련 validation
- 수정사항
  - 이름: (min:3, max:20) -> (min:1, max:30) 자
  - 소속: (min:0, max:50)자 
