### PR TITLE
app-serving: rollback 비활성화 로직 버그 수정

### DIFF
--- a/internal/delivery/http/app-serve-app.go
+++ b/internal/delivery/http/app-serve-app.go
@@ -289,18 +289,17 @@ func (h *AppServeAppHandler) GetAppServeApp(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// For very first task, rollback should be disabled.
-  if len(app.AppServeAppTasks) > 1 {
-		newTasks := make([]domain.AppServeAppTask, 0)
-		for _, t := range app.AppServeAppTasks {
-			if strings.Contains(t.Status, "SUCCESS") && t.Status != "BLUEGREEN_ABORT_SUCCESS" &&
-				t.Status != "ROLLBACK_SUCCESS" {
-				t.AvailableRollback = true
-			}
-			newTasks = append(newTasks, t)
+	newTasks := make([]domain.AppServeAppTask, 0)
+
+	for idx, t := range app.AppServeAppTasks {
+		// Rollbacking to latest task should be blocked.
+		if idx > 0 && strings.Contains(t.Status, "SUCCESS") && t.Status != "BLUEGREEN_ABORT_SUCCESS" &&
+			t.Status != "ROLLBACK_SUCCESS" {
+			t.AvailableRollback = true
 		}
-		app.AppServeAppTasks = newTasks
+		newTasks = append(newTasks, t)
 	}
+	app.AppServeAppTasks = newTasks
 
 	var out domain.GetAppServeAppResponse
 	out.AppServeApp = *app

--- a/pkg/domain/app-serve-app.go
+++ b/pkg/domain/app-serve-app.go
@@ -39,7 +39,7 @@ type AppServeAppTask struct {
 	ExtraEnv          string     `json:"extraEnv,omitempty"`                      // env variable list for java app
 	Port              string     `json:"port,omitempty"`                          // java app port
 	ResourceSpec      string     `json:"resourceSpec,omitempty"`                  // resource spec of app pod
-	HelmRevision      int32      `json:"helmRevision,omitempty"`                  // revision of deployed helm release
+	HelmRevision      int32      `gorm:"default:0" json:"helmRevision,omitempty"` // revision of deployed helm release
 	Strategy          string     `json:"strategy,omitempty"`                      // deployment strategy (eg, rolling-update)
 	PvEnabled         bool       `json:"pvEnabled"`
 	PvStorageClass    string     `json:"pvStorageClass"`


### PR DESCRIPTION
- 각 task 들에 rollback 가능 여부를 tagging하는 로직에 버그가 있어 수정하였습니다.
- helm_revision 필드의 기본값을 0으로 부여하도록 하였습니다.