### PR TITLE
Feature: 조직 생성 시 email 입력 및 로그인 시 정보 추가

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -3900,11 +3900,11 @@ const docTemplate = `{
         "domain.CreateOrganizationRequest": {
             "type": "object",
             "required": [
-                "adminEmail",
+                "Email",
                 "name"
             ],
             "properties": {
-                "adminEmail": {
+                "Email": {
                     "type": "string"
                 },
                 "description": {

--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -3900,9 +3900,13 @@ const docTemplate = `{
         "domain.CreateOrganizationRequest": {
             "type": "object",
             "required": [
+                "adminEmail",
                 "name"
             ],
             "properties": {
+                "adminEmail": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string",
                     "maxLength": 100,

--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -4677,6 +4677,9 @@ const docTemplate = `{
                         "accountId": {
                             "type": "string"
                         },
+                        "department": {
+                            "type": "string"
+                        },
                         "name": {
                             "type": "string"
                         },

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -4670,6 +4670,9 @@
                         "accountId": {
                             "type": "string"
                         },
+                        "department": {
+                            "type": "string"
+                        },
                         "name": {
                             "type": "string"
                         },

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -3893,11 +3893,11 @@
         "domain.CreateOrganizationRequest": {
             "type": "object",
             "required": [
-                "adminEmail",
+                "Email",
                 "name"
             ],
             "properties": {
-                "adminEmail": {
+                "Email": {
                     "type": "string"
                 },
                 "description": {

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -3893,9 +3893,13 @@
         "domain.CreateOrganizationRequest": {
             "type": "object",
             "required": [
+                "adminEmail",
                 "name"
             ],
             "properties": {
+                "adminEmail": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string",
                     "maxLength": 100,

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -594,7 +594,7 @@ definitions:
     type: object
   domain.CreateOrganizationRequest:
     properties:
-      adminEmail:
+      Email:
         type: string
       description:
         maxLength: 100
@@ -605,7 +605,7 @@ definitions:
       phone:
         type: string
     required:
-    - adminEmail
+    - Email
     - name
     type: object
   domain.CreateStackRequest:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -594,6 +594,8 @@ definitions:
     type: object
   domain.CreateOrganizationRequest:
     properties:
+      adminEmail:
+        type: string
       description:
         maxLength: 100
         minLength: 0
@@ -603,6 +605,7 @@ definitions:
       phone:
         type: string
     required:
+    - adminEmail
     - name
     type: object
   domain.CreateStackRequest:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1110,6 +1110,8 @@ definitions:
         properties:
           accountId:
             type: string
+          department:
+            type: string
           name:
             type: string
           organization:

--- a/internal/aws/ses/ses.go
+++ b/internal/aws/ses/ses.go
@@ -83,7 +83,7 @@ func SendEmailForVerityIdentity(client *awsSes.Client, targetEmailAddress string
 }
 
 func SendEmailForTemporaryPassword(client *awsSes.Client, targetEmailAddress string, randomPassword string) error {
-	subject := "[TKS] 비밀번호 초기화"
+	subject := "[TKS] 임시 비밀번호 발급"
 	body := "임시 비밀번호가 발급되었습니다.\n" +
 		"로그인 후 비밀번호를 변경하여 사용하십시오.\n\n" +
 		"임시 비밀번호: " + randomPassword + "\n\n" +

--- a/internal/delivery/http/organization.go
+++ b/internal/delivery/http/organization.go
@@ -58,7 +58,7 @@ func (h *OrganizationHandler) CreateOrganization(w http.ResponseWriter, r *http.
 	}
 	organization.ID = organizationId
 	// Admin user 생성
-	_, err = h.userUsecase.CreateAdmin(organizationId, input.AdminEmail)
+	_, err = h.userUsecase.CreateAdmin(organizationId, input.Email)
 	if err != nil {
 		log.Errorf("error is :%s(%T)", err.Error(), err)
 		ErrorJSON(w, err)

--- a/internal/delivery/http/organization.go
+++ b/internal/delivery/http/organization.go
@@ -58,7 +58,7 @@ func (h *OrganizationHandler) CreateOrganization(w http.ResponseWriter, r *http.
 	}
 	organization.ID = organizationId
 	// Admin user 생성
-	_, err = h.userUsecase.CreateAdmin(organizationId)
+	_, err = h.userUsecase.CreateAdmin(organizationId, input.AdminEmail)
 	if err != nil {
 		log.Errorf("error is :%s(%T)", err.Error(), err)
 		ErrorJSON(w, err)

--- a/pkg/domain/auth.go
+++ b/pkg/domain/auth.go
@@ -12,6 +12,7 @@ type LoginResponse struct {
 		Name            string       `json:"name"`
 		Token           string       `json:"token"`
 		Role            Role         `json:"role"`
+		Department      string       `json:"department"`
 		Organization    Organization `json:"organization"`
 		PasswordExpired bool         `json:"passwordExpired"`
 	} `json:"user"`

--- a/pkg/domain/organization.go
+++ b/pkg/domain/organization.go
@@ -65,7 +65,7 @@ type CreateOrganizationRequest struct {
 	Name        string `json:"name" validate:"required,name"`
 	Description string `json:"description" validate:"omitempty,min=0,max=100"`
 	Phone       string `json:"phone"`
-	AdminEmail  string `json:"adminEmail" validate:"required,email"`
+	Email       string `json:"Email" validate:"required,email"`
 }
 
 type CreateOrganizationResponse struct {

--- a/pkg/domain/organization.go
+++ b/pkg/domain/organization.go
@@ -65,6 +65,7 @@ type CreateOrganizationRequest struct {
 	Name        string `json:"name" validate:"required,name"`
 	Description string `json:"description" validate:"omitempty,min=0,max=100"`
 	Phone       string `json:"phone"`
+	AdminEmail  string `json:"adminEmail" validate:"required,email"`
 }
 
 type CreateOrganizationResponse struct {


### PR DESCRIPTION
- commit: feature: add email address on createOrganzation API
  - 변경: organization 생성 시 admin의 Email 주소를 입력하도록 하며 해당 주소로 임시 비밀번호를 발급 
- commit: minor fix: add department info on login API
  - 변경: login 시 응답에 department 정보 추가