### PR TITLE
app-serving: refactor pipeline construction

### DIFF
--- a/internal/delivery/http/app-serve-app.go
+++ b/internal/delivery/http/app-serve-app.go
@@ -307,14 +307,14 @@ func makeStage(app *domain.AppServeApp, pl string) domain.StageResponse {
 	}
 
 	var actions []domain.ActionResponse
-	if app.Status == "DEPLOY_SUCCESS" {
+	if stage.Status == "DEPLOY_SUCCESS" {
 		action := domain.ActionResponse{
 			Name: "ENDPOINT",
 			Uri:  app.EndpointUrl,
 			Type: "LINK",
 		}
 		actions = append(actions, action)
-	} else if app.Status == "PROMOTE_WAIT" && app.AppServeAppTasks[0].Strategy == "blue-green" {
+	} else if stage.Status == "PROMOTE_WAIT" && app.AppServeAppTasks[0].Strategy == "blue-green" {
 		action := domain.ActionResponse{
 			Name: "PREVIEW",
 			Uri:  app.PreviewEndpointUrl,
@@ -341,7 +341,7 @@ func makeStage(app *domain.AppServeApp, pl string) domain.StageResponse {
 			Body:   map[string]string{"strategy": "blue-green", "abort": "true"},
 		}
 		actions = append(actions, action)
-	} else if app.Status == "PROMOTE_SUCCESS" {
+	} else if stage.Status == "PROMOTE_SUCCESS" {
 		action := domain.ActionResponse{
 			Name: "ENDPOINT",
 			Uri:  app.EndpointUrl,

--- a/internal/delivery/http/app-serve-app.go
+++ b/internal/delivery/http/app-serve-app.go
@@ -18,98 +18,48 @@ import (
 
 var (
 	StatusResult = map[string]string{
-		"BUILDING":                  "BUILDING",
-		"BUILD_SUCCESS":             "DONE",
-		"BUILD_FAILED":              "FAILED",
-		"DEPLOYING":                 "DEPLOYING",
-		"DEPLOY_SUCCESS":            "DONE",
-		"DEPLOY_FAILED":             "FAILED",
-		"BLUEGREEN_DEPLOYING":       "DEPLOYING",
-		"BLUEGREEN_WAIT":            "WAIT",
-		"BLUEGREEN_DEPLOY_FAILED":   "FAILED",
-		"BLUEGREEN_PROMOTING":       "PROMOTING",
-		"BLUEGREEN_PROMOTE_SUCCESS": "DONE",
-		"BLUEGREEN_PROMOTE_FAILED":  "FAILED",
-		"BLUEGREEN_ABORTING":        "ABORTING",
-		"BLUEGREEN_ABORT_SUCCESS":   "DONE",
-		"BLUEGREEN_ABORT_FAILED":    "FAILED",
-		"CANARY_DEPLOYING":          "DEPLOYING",
-		"CANARY_WAIT":               "WAIT",
-		"CANARY_DEPLOY_FAILED":      "FAILED",
-		"CANARY_PROMOTING":          "PROMOTING",
-		"CANARY_PROMOTE_SUCCESS":    "DONE",
-		"CANARY_PROMOTE_FAILED":     "FAILED",
-		"CANARY_ABORTING":           "ABORTING",
-		"CANARY_ABORT_SUCCESS":      "DONE",
-		"CANARY_ABORT_FAILED":       "FAILED",
-		"ROLLBACKING":               "ROLLBACKING",
-		"ROLLBACK_SUCCESS":          "DONE",
-		"ROLLBACK_FAILED":           "FAILED",
-		"DELETING":                  "DELETING",
-		"DELETE_FAILED":             "FAILED",
+		"BUILDING":         "PROGRESS",
+		"BUILD_SUCCESS":    "DONE",
+		"BUILD_FAILED":     "FAILED",
+		"DEPLOYING":        "PROGRESS",
+		"DEPLOY_SUCCESS":   "DONE",
+		"DEPLOY_FAILED":    "FAILED",
+		"PROMOTE_WAIT":     "WAITING",
+		"PROMOTING":        "PROGRESS",
+		"PROMOTE_SUCCESS":  "DONE",
+		"PROMOTE_FAILED":   "FAILED",
+		"ABORTING":         "PROGRESS",
+		"ABORT_SUCCESS":    "DONE",
+		"ABORT_FAILED":     "FAILED",
+		"ROLLBACKING":      "PROGRESS",
+		"ROLLBACK_SUCCESS": "DONE",
+		"ROLLBACK_FAILED":  "FAILED",
+		"DELETING":         "PROGRESS",
+		"DELETE_SUCCESS":   "DONE",
+		"DELETE_FAILED":    "FAILED",
+		"WAITING":          "WAITING",
 	}
-	StatusName = map[string]string{
-		"BUILDING":                  "BUILD",
-		"BUILD_SUCCESS":             "BUILD",
-		"BUILD_FAILED":              "BUILD",
-		"DEPLOYING":                 "DEPLOY",
-		"DEPLOY_SUCCESS":            "DEPLOY",
-		"DEPLOY_FAILED":             "DEPLOY",
-		"BLUEGREEN_DEPLOYING":       "PROMOTE",
-		"BLUEGREEN_WAIT":            "PROMOTE",
-		"BLUEGREEN_DEPLOY_FAILED":   "PROMOTE",
-		"BLUEGREEN_PROMOTING":       "PROMOTE",
-		"BLUEGREEN_PROMOTE_SUCCESS": "PROMOTE",
-		"BLUEGREEN_PROMOTE_FAILED":  "PROMOTE",
-		"BLUEGREEN_ABORTING":        "PROMOTE",
-		"BLUEGREEN_ABORT_SUCCESS":   "PROMOTE",
-		"BLUEGREEN_ABORT_FAILED":    "PROMOTE",
-		"CANARY_DEPLOYING":          "PROMOTE",
-		"CANARY_WAIT":               "PROMOTE",
-		"CANARY_DEPLOY_FAILED":      "PROMOTE",
-		"CANARY_PROMOTING":          "PROMOTE",
-		"CANARY_PROMOTE_SUCCESS":    "PROMOTE",
-		"CANARY_PROMOTE_FAILED":     "PROMOTE",
-		"CANARY_ABORTING":           "PROMOTE",
-		"CANARY_ABORT_SUCCESS":      "PROMOTE",
-		"CANARY_ABORT_FAILED":       "PROMOTE",
-		"ROLLBACKING":               "ROLLBACK",
-		"ROLLBACK_SUCCESS":          "ROLLBACK",
-		"ROLLBACK_FAILED":           "ROLLBACK",
-		"DELETING":                  "DELETE",
-		"DELETE_FAILED":             "DELETE",
-	}
-	StatusStages = map[string][]string{
-		"PREPARING":                 {},
-		"BUILDING":                  {"BUILDING"},
-		"BUILD_SUCCESS":             {"BUILD_SUCCESS"},
-		"BUILD_FAILED":              {"BUILD_FAILED"},
-		"DEPLOYING":                 {"BUILD_SUCCESS", "DEPLOYING"},
-		"DEPLOY_SUCCESS":            {"BUILD_SUCCESS", "DEPLOY_SUCCESS"},
-		"DEPLOY_FAILED":             {"BUILD_SUCCESS", "DEPLOY_FAILED"},
-		"BLUEGREEN_DEPLOYING":       {"BUILD_SUCCESS", "DEPLOYING"},
-		"BLUEGREEN_DEPLOY_FAILED":   {"BUILD_SUCCESS", "DEPLOY_FAILED"},
-		"BLUEGREEN_WAIT":            {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "BLUEGREEN_WAIT"},
-		"BLUEGREEN_PROMOTING":       {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "BLUEGREEN_PROMOTING"},
-		"BLUEGREEN_PROMOTE_SUCCESS": {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "BLUEGREEN_PROMOTE_SUCCESS"},
-		"BLUEGREEN_PROMOTE_FAILED":  {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "BLUEGREEN_PROMOTE_FAILED"},
-		"BLUEGREEN_ABORTING":        {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "BLUEGREEN_ABORTING"},
-		"BLUEGREEN_ABORT_SUCCESS":   {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "BLUEGREEN_ABORT_SUCCESS"},
-		"BLUEGREEN_ABORT_FAILED":    {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "BLUEGREEN_ABORT_FAILED"},
-		"CANARY_DEPLOYING":          {"BUILD_SUCCESS", "DEPLOYING"},
-		"CANARY_DEPLOY_FAILED":      {"BUILD_SUCCESS", "DEPLOY_FAILED"},
-		"CANARY_WAIT":               {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "CANARY_WAIT"},
-		"CANARY_PROMOTING":          {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "CANARY_PROMOTING"},
-		"CANARY_PROMOTE_SUCCESS":    {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "CANARY_PROMOTE_SUCCESS"},
-		"CANARY_PROMOTE_FAILED":     {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "CANARY_PROMOTE_FAILED"},
-		"CANARY_ABORTING":           {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "CANARY_ABORTING"},
-		"CANARY_ABORT_SUCCESS":      {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "CANARY_ABORT_SUCCESS"},
-		"CANARY_ABORT_FAILED":       {"BUILD_SUCCESS", "DEPLOY_SUCCESS", "CANARY_ABORT_FAILED"},
-		"ROLLBACKING":               {"ROLLBACKING"},
-		"ROLLBACK_SUCCESS":          {"ROLLBACK_SUCCESS"},
-		"ROLLBACK_FAILED":           {"ROLLBACK_FAILED"},
-		"DELETING":                  {"DELETING"},
-		"DELETE_FAILED":             {"DELETE_FAILED"},
+	StatusStages = map[string]map[string]string{
+		"PREPARING":        {"build": "WAITING", "deploy": "WAITING", "promote": "WAITING"},
+		"BUILDING":         {"build": "BUILDING", "deploy": "WAITING", "promote": "WAITING"},
+		"BUILD_SUCCESS":    {"build": "BUILD_SUCCESS", "deploy": "WAITING", "promote": "WAITING"},
+		"BUILD_FAILED":     {"build": "BUILD_FAILED", "deploy": "WAITING", "promote": "WAITING"},
+		"DEPLOYING":        {"build": "BUILD_SUCCESS", "deploy": "DEPLOYING", "promote": "WAITING"},
+		"DEPLOY_SUCCESS":   {"build": "BUILD_SUCCESS", "deploy": "DEPLOY_SUCCESS", "promote": "WAITING"},
+		"DEPLOY_FAILED":    {"build": "BUILD_SUCCESS", "deploy": "DEPLOY_FAILED", "promote": "WAITING"},
+		"PROMOTE_WAIT":     {"build": "BUILD_SUCCESS", "deploy": "DEPLOY_SUCCESS", "promote": "PROMOTE_WAIT"},
+		"PROMOTING":        {"build": "BUILD_SUCCESS", "deploy": "DEPLOY_SUCCESS", "promote": "PROMOTING"},
+		"PROMOTE_SUCCESS":  {"build": "BUILD_SUCCESS", "deploy": "DEPLOY_SUCCESS", "promote": "PROMOTE_SUCCESS"},
+		"PROMOTE_FAILED":   {"build": "BUILD_SUCCESS", "deploy": "DEPLOY_SUCCESS", "promote": "PROMOTE_FAILED"},
+		"ABORTING":         {"build": "BUILD_SUCCESS", "deploy": "DEPLOY_SUCCESS", "promote": "ABORTING"},
+		"ABORT_SUCCESS":    {"build": "BUILD_SUCCESS", "deploy": "DEPLOY_SUCCESS", "promote": "ABORT_SUCCESS"},
+		"ABORT_FAILED":     {"build": "BUILD_SUCCESS", "deploy": "DEPLOY_SUCCESS", "promote": "ABORT_FAILED"},
+		"ROLLBACKING":      {"rollback": "ROLLBACKING"},
+		"ROLLBACK_SUCCESS": {"rollback": "ROLLBACK_SUCCESS"},
+		"ROLLBACK_FAILED":  {"rollback": "ROLLBACK_FAILED"},
+		"DELETING":         {"delete": "DELETING"},
+		"DELETE_SUCCESS":   {"delete": "DELETE_SUCCESS"},
+		"DELETE_FAILED":    {"delete": "DELETE_FAILED"},
 	}
 )
 
@@ -293,7 +243,7 @@ func (h *AppServeAppHandler) GetAppServeApp(w http.ResponseWriter, r *http.Reque
 
 	for idx, t := range app.AppServeAppTasks {
 		// Rollbacking to latest task should be blocked.
-		if idx > 0 && strings.Contains(t.Status, "SUCCESS") && t.Status != "BLUEGREEN_ABORT_SUCCESS" &&
+		if idx > 0 && strings.Contains(t.Status, "SUCCESS") && t.Status != "ABORT_SUCCESS" &&
 			t.Status != "ROLLBACK_SUCCESS" {
 			t.AvailableRollback = true
 		}
@@ -305,49 +255,66 @@ func (h *AppServeAppHandler) GetAppServeApp(w http.ResponseWriter, r *http.Reque
 	out.AppServeApp = *app
 	out.Stages = makeStages(app)
 
+	// Robert: temporary debug
+	fmt.Printf("stage response:\n %+v\n", out)
+
 	ResponseJSON(w, http.StatusOK, out)
 }
 
-// Name             - Status (Result)
-// -------------------------------------------------------------------------------------
-// PREPARE (준비)              - PREPARING (DONE)
-// BUILD (빌드)                - BUILDING (BUILDING),              BUILD_SUCCESS (DONE),             BUILD_FAILED (FAILED)
-// DEPLOY (배포)               - DEPLOYING (DEPLOYING),            DEPLOY_SUCCESS (DONE),            DEPLOY_FAILED (FAILED)
-// BLUEGREEN_PROMOTE (프로모트) - BLUEGREEN_DEPLOYING (DEPLOYING),  BLUEGREEN_WAIT (WAIT),            BLUEGREEN_DEPLOY_FAILED (FAILED)
-// BLUEGREEN_PROMOTE (프로모트) - BLUEGREEN_PROMOTING (PROMOTING),  BLUEGREEN_PROMOTE_SUCCESS (DONE), BLUEGREEN_PROMOTE_FAILED (FAILED)
-// BLUEGREEN_PROMOTE (프로모트) - BLUEGREEN_ABORTING (ABORTING),    BLUEGREEN_ABORT_SUCCESS (DONE),   BLUEGREEN_ABORT_FAILED (FAILED)
-// CANARY_PROMOTE (카나리아)    - CANARY_DEPLOYING (DEPLOYING),     CANARY_WAIT (WAIT),               CANARY_DEPLOY_FAILED (FAILED)
-// CANARY_PROMOTE (카나리아)    - CANARY_PROMOTING (PROMOTING),     CANARY_PROMOTE_SUCCESS (DONE),    CANARY_PROMOTE_FAILED (FAILED)
-// CANARY_PROMOTE (카나리아)    - CANARY_ABORTING (ABORTING),       CANARY_ABORT_SUCCESS (DONE),      CANARY_ABORT_FAILED (FAILED)
-// ROLLBACK (롤백)             - ROLLBACKING (ROLLBACKING),        ROLLBACK_SUCCESS (DONE),          ROLLBACK_FAILED (FAILED)
 func makeStages(app *domain.AppServeApp) []domain.StageResponse {
 	stages := make([]domain.StageResponse, 0)
 
 	var stage domain.StageResponse
-	for _, s := range StatusStages[app.Status] {
-		stage = makeStage(app, s)
+	var pipelines []string
+
+	if app.Type == "all" {
+		if app.AppServeAppTasks[0].Status == "ROLLBACKING" ||
+			app.AppServeAppTasks[0].Status == "ROLLBACK_SUCCESS" ||
+			app.AppServeAppTasks[0].Status == "ROLLBACK_FAILED" {
+			pipelines = []string{"rollback"}
+		} else if app.AppServeAppTasks[0].Status == "DELETING" ||
+			app.AppServeAppTasks[0].Status == "DELETE_SUCCESS" ||
+			app.AppServeAppTasks[0].Status == "DELETE_FAILED" {
+			pipelines = []string{"delete"}
+		} else if app.AppServeAppTasks[0].Strategy == "rolling-update" {
+			pipelines = []string{"build", "deploy"}
+		} else if app.AppServeAppTasks[0].Strategy == "blue-green" {
+			pipelines = []string{"build", "deploy", "promote"}
+		}
+	} else if app.Type == "deploy" {
+		if app.AppServeAppTasks[0].Strategy == "rolling-update" {
+			pipelines = []string{"deploy"}
+		} else if app.AppServeAppTasks[0].Strategy == "blue-green" {
+			pipelines = []string{"deploy", "promote"}
+		}
+	}
+
+	fmt.Printf("Pipeline stages: %v\n", pipelines)
+
+	for _, pl := range pipelines {
+		stage = makeStage(app, pl)
 		stages = append(stages, stage)
 	}
 
 	return stages
 }
 
-func makeStage(app *domain.AppServeApp, status string) domain.StageResponse {
+func makeStage(app *domain.AppServeApp, pl string) domain.StageResponse {
 	stage := domain.StageResponse{
-		Name:   StatusName[status],
-		Status: status,
-		Result: StatusResult[status],
+		Name:   pl,
+		Status: StatusStages[app.Status][pl],
+		Result: StatusResult[StatusStages[app.Status][pl]],
 	}
 
 	var actions []domain.ActionResponse
-	if status == "DEPLOY_SUCCESS" {
+	if app.Status == "DEPLOY_SUCCESS" {
 		action := domain.ActionResponse{
 			Name: "ENDPOINT",
 			Uri:  app.EndpointUrl,
 			Type: "LINK",
 		}
 		actions = append(actions, action)
-	} else if status == "BLUEGREEN_WAIT" {
+	} else if app.Status == "PROMOTE_WAIT" && app.AppServeAppTasks[0].Strategy == "blue-green" {
 		action := domain.ActionResponse{
 			Name: "PREVIEW",
 			Uri:  app.PreviewEndpointUrl,
@@ -374,7 +341,7 @@ func makeStage(app *domain.AppServeApp, status string) domain.StageResponse {
 			Body:   map[string]string{"strategy": "blue-green", "abort": "true"},
 		}
 		actions = append(actions, action)
-	} else if status == "BLUEGREEN_PROMOTE_SUCCESS" {
+	} else if app.Status == "PROMOTE_SUCCESS" {
 		action := domain.ActionResponse{
 			Name: "ENDPOINT",
 			Uri:  app.EndpointUrl,
@@ -537,7 +504,8 @@ func (h *AppServeAppHandler) UpdateAppServeApp(w http.ResponseWriter, r *http.Re
 	//}
 
 	// priority: 3. previous task
-	var latestTask = app.AppServeAppTasks[len(app.AppServeAppTasks)-1]
+	//var latestTask = app.AppServeAppTasks[len(app.AppServeAppTasks)-1]
+	var latestTask = app.AppServeAppTasks[0]
 	if err = domain.Map(latestTask, &task); err != nil {
 		ErrorJSON(w, httpErrors.NewBadRequestError(err, "", ""))
 		return

--- a/internal/usecase/app-serve-app.go
+++ b/internal/usecase/app-serve-app.go
@@ -416,7 +416,7 @@ func (u *AppServeAppUsecase) PromoteAppServeApp(appId string) (ret string, err e
 	log.Info("latestTaskId = ", latestTaskId)
 	log.Info("strategy = ", strategy)
 
-	log.Info("Updating app status to 'PREPARING'..")
+	log.Info("Updating app status to 'PROMOTING'..")
 
 	err = u.repo.UpdateStatus(appId, latestTaskId, "PROMOTING", "")
 	if err != nil {
@@ -462,11 +462,20 @@ func (u *AppServeAppUsecase) AbortAppServeApp(appId string) (ret string, err err
 		return "", fmt.Errorf("The app is not waiting for promote. Exiting..")
 	}
 
-	// Get the latest task ID so that the task status can be modified inside workflow once the promotion is done.
+	// Get the latest task ID so that the task status can be modified inside workflow once the abort process is done.
 	latestTaskId := app.AppServeAppTasks[0].ID
 	strategy := app.AppServeAppTasks[0].Strategy
 	log.Info("latestTaskId = ", latestTaskId)
 	log.Info("strategy = ", strategy)
+
+	log.Info("Updating app status to 'ABORTING'..")
+
+	err = u.repo.UpdateStatus(appId, latestTaskId, "ABORTING", "")
+	if err != nil {
+		log.Debug("appId = ", appId)
+		log.Debug("taskId = ", latestTaskId)
+		return "", fmt.Errorf("failed to update app status on AbortAppServeApp. Err: %s", err)
+	}
 
 	// Call argo workflow
 	workflow := "abort-java-app"


### PR DESCRIPTION
- pass entire stages regardless of current status
UI 에서 파이프라인 현황을 보여주기 위해 항상 static하게 전체 stage를 리턴하도록 수정

- update app status before calling workflow
기존에 작업 요청 후 workflow에서 최초로 상태를 갱신하던 것을, API 에서 즉시 상태를 갱신하도록 수정
(workflow 생성 delay로 인해 UI에서 화면 갱신 안되던 문제 해결)

https://github.com/openinfradev/tks-flow/pull/188 도 함께 머지되어야 합니다