### PR TITLE
minor fix: set passwordExpired flag on org admin account

### DIFF
--- a/internal/aws/ses/ses.go
+++ b/internal/aws/ses/ses.go
@@ -120,8 +120,8 @@ func SendEmailForGeneratingOrganization(client *awsSes.Client, organizationId st
 	targetEmailAddress string, userAccountId string, randomPassword string) error {
 	subject := "[TKS] 조직이 생성되었습니다."
 	body := "조직이 생성되었습니다. \n" +
-		"조직 ID: " + organizationId +
-		"조직 이름: " + organizationName +
+		"조직 ID: " + organizationId + "\n" +
+		"조직 이름: " + organizationName + "\n\n" +
 		"아래 관리자 계정 정보로 로그인 후 사용바랍니다.\n" +
 		"관리자 ID: " + userAccountId + "\n" +
 		"관리자 이름: admin\n" +

--- a/internal/middleware/auth/authorizer/password.go
+++ b/internal/middleware/auth/authorizer/password.go
@@ -26,7 +26,7 @@ func PasswordFilter(handler http.Handler, repo repository.Repository) http.Handl
 			return
 		}
 		//TODO: 임시로 admin 계정은 비밀번호 변경 기간을 무시하도록 함. 추후 설계 필요
-		if storedUser.AccountId == "admin" {
+		if storedUser.Organization.ID == "master" && storedUser.AccountId == "admin" {
 			handler.ServeHTTP(w, r)
 			return
 		}

--- a/internal/middleware/auth/authorizer/password.go
+++ b/internal/middleware/auth/authorizer/password.go
@@ -25,7 +25,7 @@ func PasswordFilter(handler http.Handler, repo repository.Repository) http.Handl
 			internalHttp.ErrorJSON(w, err)
 			return
 		}
-		//TODO: 임시로 admin 계정은 비밀번호 변경 기간을 무시하도록 함. 추후 설계 필요
+		//TODO: TKS control plane 동작을 위해, master 조직의 admin 계정은 비밀번호 변경 기간을 무시하도록 함.
 		if storedUser.Organization.ID == "master" && storedUser.AccountId == "admin" {
 			handler.ServeHTTP(w, r)
 			return

--- a/internal/usecase/auth.go
+++ b/internal/usecase/auth.go
@@ -128,7 +128,9 @@ func (u *AuthUsecase) Login(accountId string, password string, organizationId st
 	// Insert token
 	user.Token = accountToken.Token
 
-	user.PasswordExpired = helper.IsDurationExpired(user.PasswordUpdatedAt, internal.PasswordExpiredDuration)
+	if !(organizationId == "master" && accountId == "admin") {
+		user.PasswordExpired = helper.IsDurationExpired(user.PasswordUpdatedAt, internal.PasswordExpiredDuration)
+	}
 
 	return user, nil
 }

--- a/internal/usecase/user.go
+++ b/internal/usecase/user.go
@@ -254,6 +254,10 @@ func (u *UserUsecase) CreateAdmin(orgainzationId string, email string) (*domain.
 	if err != nil {
 		return nil, err
 	}
+	err = u.userRepository.UpdatePassword(userUuid, user.Organization.ID, hashedPassword, true)
+	if err != nil {
+		return nil, err
+	}
 
 	organizationInfo, err := u.organizationRepository.Get(orgainzationId)
 	if err != nil {


### PR DESCRIPTION
QA 과정 중 나온 의견으로 조직 생성 후, 초기 admin 계정으로 로그인 시 비밀번호 변경 화면이 나왔으면 좋겠다는 의견을 수렴하여 로직 변경.

조직생성 과정에서 자동으로 생성된 admin 계정에 대해 "passwordExpired" flag를 설정한다.

