### PR TITLE
bugfix: shouldn't set default value for update task

### DIFF
--- a/internal/delivery/http/app-serve-app.go
+++ b/internal/delivery/http/app-serve-app.go
@@ -500,10 +500,6 @@ func (h *AppServeAppHandler) UpdateAppServeApp(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// priority
-	// 1. Request,  2. default value  3. previous app and task
-
-	// priority: 3. previous app
 	app, err := h.usecase.GetAppServeAppById(appId)
 	if err != nil {
 		ErrorJSON(w, r, err)
@@ -513,7 +509,6 @@ func (h *AppServeAppHandler) UpdateAppServeApp(w http.ResponseWriter, r *http.Re
 		ErrorJSON(w, r, err)
 	}
 
-	// priority: 1. Request
 	appReq := domain.UpdateAppServeAppRequest{}
 	err = UnmarshalRequestInput(r, &appReq)
 	if err != nil {
@@ -521,8 +516,13 @@ func (h *AppServeAppHandler) UpdateAppServeApp(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// priority: 2. Default Value
-	appReq.SetDefaultValue()
+	// Instead of setting default value, some fields should be retrieved
+	// from existing app config.
+	//appReq.SetDefaultValue()
+
+	appReq.Type = app.Type
+	appReq.AppType = app.AppType
+	appReq.Namespace = app.Namespace
 
 	if err = domain.Map(appReq, app); err != nil {
 		//ErrorJSON(w, r, httpErrors.NewBadRequestError(err, "", ""))
@@ -545,15 +545,12 @@ func (h *AppServeAppHandler) UpdateAppServeApp(w http.ResponseWriter, r *http.Re
 	//	return
 	//}
 
-	// priority: 3. previous task
-	//var latestTask = app.AppServeAppTasks[len(app.AppServeAppTasks)-1]
 	var latestTask = app.AppServeAppTasks[0]
 	if err = domain.Map(latestTask, &task); err != nil {
 		//ErrorJSON(w, r, httpErrors.NewBadRequestError(err, "", ""))
 		return
 	}
 
-	// priority: 1. Request
 	if err = domain.Map(appReq, &task); err != nil {
 		//ErrorJSON(w, r, httpErrors.NewBadRequestError(err, "", ""))
 		return

--- a/internal/delivery/http/app-serve-app.go
+++ b/internal/delivery/http/app-serve-app.go
@@ -130,14 +130,14 @@ func (h *AppServeAppHandler) CreateAppServeApp(w http.ResponseWriter, r *http.Re
 	// Validate port param for springboot app
 	if app.AppType == "springboot" {
 		if task.Port == "" {
-			ErrorJSON(w, httpErrors.NewBadRequestError(fmt.Errorf("error: 'port' param is mandatory"), "", ""))
+			ErrorJSON(w, r, httpErrors.NewBadRequestError(fmt.Errorf("error: 'port' param is mandatory"), "", ""))
 			return
 		}
 	}
 
 	// Validate 'strategy' param
 	if task.Strategy != "rolling-update" {
-		ErrorJSON(w, httpErrors.NewBadRequestError(
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(
 			fmt.Errorf("error: 'strategy' should be 'rolling-update' on first deployment"), "", ""))
 		return
 	}

--- a/internal/delivery/http/app-serve-app.go
+++ b/internal/delivery/http/app-serve-app.go
@@ -129,15 +129,15 @@ func (h *AppServeAppHandler) CreateAppServeApp(w http.ResponseWriter, r *http.Re
 
 	// Validate port param for springboot app
 	if app.AppType == "springboot" {
-		if app.AppServeAppTasks[0].Port == "" {
-			ErrorJSON(w, r, httpErrors.NewBadRequestError(fmt.Errorf("error: 'port' param is mandatory"), "", ""))
+		if task.Port == "" {
+			ErrorJSON(w, httpErrors.NewBadRequestError(fmt.Errorf("error: 'port' param is mandatory"), "", ""))
 			return
 		}
 	}
 
 	// Validate 'strategy' param
-	if app.AppServeAppTasks[0].Strategy != "rolling-update" {
-		ErrorJSON(w, r, httpErrors.NewBadRequestError(
+	if task.Strategy != "rolling-update" {
+		ErrorJSON(w, httpErrors.NewBadRequestError(
 			fmt.Errorf("error: 'strategy' should be 'rolling-update' on first deployment"), "", ""))
 		return
 	}

--- a/internal/delivery/http/app-serve-app.go
+++ b/internal/delivery/http/app-serve-app.go
@@ -258,6 +258,47 @@ func (h *AppServeAppHandler) GetAppServeApp(w http.ResponseWriter, r *http.Reque
 	ResponseJSON(w, r, http.StatusOK, out)
 }
 
+// GetAppServeAppLatestTask godoc
+// @Tags AppServeApps
+// @Summary Get latest task from appServeApp
+// @Description Get latest task from appServeApp
+// @Accept json
+// @Produce json
+// @Success 200 {object} domain.GetAppServeAppTaskResponse
+// @Router /organizations/{organizationId}/app-serve-apps/{appId}/latest-task [get]
+// @Security     JWT
+func (h *AppServeAppHandler) GetAppServeAppLatestTask(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	organizationId, ok := vars["organizationId"]
+	fmt.Printf("organizationId = [%v]\n", organizationId)
+	if !ok {
+		ErrorJSON(w, httpErrors.NewBadRequestError(fmt.Errorf("invalid organizationId"), "", ""))
+		return
+	}
+
+	appId, ok := vars["appId"]
+	fmt.Printf("appId = [%s]\n", appId)
+	if !ok {
+		ErrorJSON(w, httpErrors.NewBadRequestError(fmt.Errorf("invalid appId"), "", ""))
+		return
+	}
+	task, err := h.usecase.GetAppServeAppLatestTask(appId)
+	if err != nil {
+		ErrorJSON(w, httpErrors.NewInternalServerError(err, "", ""))
+		return
+	}
+	if task == nil {
+		ErrorJSON(w, httpErrors.NewNoContentError(fmt.Errorf("no task exists"), "", ""))
+		return
+	}
+
+	var out domain.GetAppServeAppTaskResponse
+	out.AppServeAppTask = *task
+
+	ResponseJSON(w, http.StatusOK, out)
+}
+
 func makeStages(app *domain.AppServeApp) []domain.StageResponse {
 	stages := make([]domain.StageResponse, 0)
 

--- a/internal/repository/app-serve-app.go
+++ b/internal/repository/app-serve-app.go
@@ -14,6 +14,7 @@ type IAppServeAppRepository interface {
 	CreateAppServeApp(app *domain.AppServeApp) (appId string, taskId string, err error)
 	GetAppServeApps(organizationId string, showAll bool) ([]domain.AppServeApp, error)
 	GetAppServeAppById(appId string) (*domain.AppServeApp, error)
+	GetAppServeAppLatestTask(appId string) (*domain.AppServeAppTask, error)
 	IsAppServeAppExist(appId string) (int64, error)
 	IsAppServeAppNameExist(orgId string, appName string) (int64, error)
 	CreateTask(task *domain.AppServeAppTask) (taskId string, err error)
@@ -99,6 +100,21 @@ func (r *AppServeAppRepository) GetAppServeAppById(appId string) (*domain.AppSer
 	//}
 
 	return &app, nil
+}
+
+func (r *AppServeAppRepository) GetAppServeAppLatestTask(appId string) (*domain.AppServeAppTask, error) {
+	var task domain.AppServeAppTask
+
+	res := r.db.Order("created_at desc").First(&task)
+	if res.Error != nil {
+		log.Debug(res.Error)
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, nil
+	}
+
+	return &task, nil
 }
 
 func (r *AppServeAppRepository) IsAppServeAppExist(appId string) (int64, error) {

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -127,7 +127,10 @@ func SetupRouter(db *gorm.DB, argoClient argowf.ArgoClient, kc keycloak.IKeycloa
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/app-serve-apps", authMiddleware.Handle(http.HandlerFunc(appServeAppHandler.CreateAppServeApp))).Methods(http.MethodPost)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/app-serve-apps", authMiddleware.Handle(http.HandlerFunc(appServeAppHandler.GetAppServeApps))).Methods(http.MethodGet)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/app-serve-apps/{appId}", authMiddleware.Handle(http.HandlerFunc(appServeAppHandler.GetAppServeApp))).Methods(http.MethodGet)
-	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/app-serve-apps/app-id/exist", authMiddleware.Handle(http.HandlerFunc(appServeAppHandler.IsAppServeAppExist))).Methods(http.MethodGet)
+	// TODO: To be implemented
+	//	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/app-serve-apps/{appId}/tasks/{taskId}", authMiddleware.Handle(http.HandlerFunc(appServeAppHandler.GetAppServeAppTask))).Methods(http.MethodGet)
+	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/app-serve-apps/{appId}/latest-task", authMiddleware.Handle(http.HandlerFunc(appServeAppHandler.GetAppServeAppLatestTask))).Methods(http.MethodGet)
+	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/app-serve-apps/{appId}/exist", authMiddleware.Handle(http.HandlerFunc(appServeAppHandler.IsAppServeAppExist))).Methods(http.MethodGet)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/app-serve-apps/name/{name}/existence", authMiddleware.Handle(http.HandlerFunc(appServeAppHandler.IsAppServeAppNameExist))).Methods(http.MethodGet)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/app-serve-apps/{appId}", authMiddleware.Handle(http.HandlerFunc(appServeAppHandler.DeleteAppServeApp))).Methods(http.MethodDelete)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/app-serve-apps/{appId}", authMiddleware.Handle(http.HandlerFunc(appServeAppHandler.UpdateAppServeApp))).Methods(http.MethodPut)

--- a/internal/usecase/app-serve-app.go
+++ b/internal/usecase/app-serve-app.go
@@ -21,6 +21,7 @@ type IAppServeAppUsecase interface {
 	CreateAppServeApp(app *domain.AppServeApp) (appId string, taskId string, err error)
 	GetAppServeApps(organizationId string, showAll bool) ([]domain.AppServeApp, error)
 	GetAppServeAppById(appId string) (*domain.AppServeApp, error)
+	GetAppServeAppLatestTask(appId string) (*domain.AppServeAppTask, error)
 	IsAppServeAppExist(appId string) (bool, error)
 	IsAppServeAppNameExist(orgId string, appName string) (bool, error)
 	UpdateAppServeAppStatus(appId string, taskId string, status string, output string) (ret string, err error)
@@ -156,6 +157,15 @@ func (u *AppServeAppUsecase) GetAppServeAppById(appId string) (*domain.AppServeA
 	}
 
 	return app, nil
+}
+
+func (u *AppServeAppUsecase) GetAppServeAppLatestTask(appId string) (*domain.AppServeAppTask, error) {
+	task, err := u.repo.GetAppServeAppLatestTask(appId)
+	if err != nil {
+		return nil, err
+	}
+
+	return task, nil
 }
 
 func (u *AppServeAppUsecase) IsAppServeAppExist(appId string) (bool, error) {

--- a/pkg/domain/app-serve-app.go
+++ b/pkg/domain/app-serve-app.go
@@ -190,8 +190,12 @@ type GetAppServeAppResponse struct {
 	Stages      []StageResponse `json:"stages"`
 }
 
+type GetAppServeAppTaskResponse struct {
+	AppServeAppTask AppServeAppTask `json:"appServeAppTask"`
+}
+
 type StageResponse struct {
-	Name    string            `json:"name"` // PREPARE (준비), BUILD (빌드), DEPLOY (배포), PROMOTE (프로모트), ROLLBACK (롤백)
+	Name    string            `json:"name"` // BUILD (빌드), DEPLOY (배포), PROMOTE (프로모트), ROLLBACK (롤백)
 	Status  string            `json:"status"`
 	Result  string            `json:"result"`
 	Actions *[]ActionResponse `json:"actions"`


### PR DESCRIPTION
https://github.com/openinfradev/tks-issues/issues/687

type, app_type, namespace 등 task 가 아닌 app 자체에 속한 정보들은 UI에서 update API 호출시 전달하지 않는 정보들이므로, DB에 이미 가지고 있는 원래의 app 설정을 그대로 재사용하도록 수정하였습니다. 

추가로, GetLatestTask 라는 API 를 추가하였는데, 이부분은 당장 사용하지 않지만 향후 필요하여 미리 추가해놓았습니다.
