### PR TITLE
minor fix: change error code and return code

### DIFF
--- a/internal/delivery/http/user.go
+++ b/internal/delivery/http/user.go
@@ -460,7 +460,7 @@ func (u UserHandler) UpdateMyPassword(w http.ResponseWriter, r *http.Request) {
 	err = u.usecase.UpdatePasswordByAccountId(r.Context(), user.AccountId, input.OriginPassword, input.NewPassword, requestUserInfo.GetOrganizationId())
 	if err != nil {
 		if strings.Contains(err.Error(), "invalid origin password") {
-			ErrorJSON(w, r, httpErrors.NewUnauthorizedError(err, "A_INVALID_ORIGIN_PASSWORD", ""))
+			ErrorJSON(w, r, httpErrors.NewBadRequestError(err, "A_INVALID_ORIGIN_PASSWORD", ""))
 			return
 		}
 

--- a/internal/usecase/auth.go
+++ b/internal/usecase/auth.go
@@ -165,7 +165,7 @@ func (u *AuthUsecase) FindId(code string, email string, userName string, organiz
 		return "", httpErrors.NewBadRequestError(fmt.Errorf("expired code"), "A_EXPIRED_CODE", "")
 	}
 	if emailCode.Code != code {
-		return "", httpErrors.NewBadRequestError(fmt.Errorf("invalid code"), "A_MISMATCH_CODE", "")
+		return "", httpErrors.NewBadRequestError(fmt.Errorf("invalid code"), "A_INVALID_CODE", "")
 	}
 	if err := u.authRepository.DeleteEmailCode(userUuid); err != nil {
 		return "", httpErrors.NewInternalServerError(err, "", "")
@@ -197,7 +197,7 @@ func (u *AuthUsecase) FindPassword(code string, accountId string, email string, 
 		return httpErrors.NewBadRequestError(fmt.Errorf("expired code"), "A_EXPIRED_CODE", "")
 	}
 	if emailCode.Code != code {
-		return httpErrors.NewBadRequestError(fmt.Errorf("invalid code"), "A_MISMATCH_CODE", "")
+		return httpErrors.NewBadRequestError(fmt.Errorf("invalid code"), "A_INVALID_CODE", "")
 	}
 	randomPassword := helper.GenerateRandomString(passwordLength)
 

--- a/pkg/httpErrors/errorCode.go
+++ b/pkg/httpErrors/errorCode.go
@@ -21,8 +21,7 @@ var errorMap = map[ErrorCode]string{
 	"A_INVALID_TOKEN":           "사용자 토큰 오류",
 	"A_INVALID_USER_CREDENTIAL": "비밀번호가 일치하지 않습니다.",
 	"A_INVALID_ORIGIN_PASSWORD": "기존 비밀번호가 일치하지 않습니다.",
-	"A_MISMATCH_PASSWORD":       "비밀번호가 일치하지 않습니다.",
-	"A_MISMATCH_CODE":           "인증번호가 일치하지 않습니다.",
+	"A_INVALID_CODE":           "인증번호가 일치하지 않습니다.",
 	"A_NO_SESSION":              "세션 정보를 찾을 수 없습니다.",
 	"A_EXPIRED_CODE":            "인증번호가 만료되었습니다.",
 


### PR DESCRIPTION
수정사항: 
- 내 비밀번호 변경 API에서 기존 비밀번호 입력 오류시 401 return -> 400 return 수정
- 일부 Auth Error Code 의 prefix를 MISMATCH -> INVALID 로 수정