### PR TITLE
[bug-fix] app-serving: init rollback ver on update

### DIFF
--- a/internal/delivery/http/app-serve-app.go
+++ b/internal/delivery/http/app-serve-app.go
@@ -573,6 +573,7 @@ func (h *AppServeAppHandler) UpdateAppServeApp(w http.ResponseWriter, r *http.Re
 	task.Version = strconv.Itoa(len(app.AppServeAppTasks) + 1)
 	//task.AppServeAppId = app.ID
 	task.Status = "PREPARING"
+	task.RollbackVersion = ""
 	task.Output = ""
 	task.CreatedAt = time.Now()
 	task.UpdatedAt = nil


### PR DESCRIPTION
https://github.com/openinfradev/tks-console/pull/154 에서 발견된 버그 픽스입니다. 
update시에 rollback 버전 초기화하도록 수정.

@Siyeop 현재는 empty string이지만 향후 int 값으로 바뀌면 그땐 0 으로 보낼 예정입니다.