### PR TITLE
minor fix: set tls skip verification between keycloak and tks-api

### DIFF
--- a/internal/usecase/auth.go
+++ b/internal/usecase/auth.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -358,7 +359,11 @@ func makingCookie(organizationId, userName, password string) ([]*http.Cookie, er
 	}
 
 	authCodeUrl := oauth2Config.AuthCodeURL(stateCode, oauth2.AccessTypeOnline)
-	client := &http.Client{}
+	// skip tls check
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: transport}
 	req, err := http.NewRequest("GET", authCodeUrl, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
수정 사항:
- tks-api 와 keycloak은 같은 클러스터 내에 배치되므로 둘간 통신에 대해 "tls verification"기능 off

