### PR TITLE
minor fix: change default secret value to variable value for production

### DIFF
--- a/internal/keycloak/keycloak.go
+++ b/internal/keycloak/keycloak.go
@@ -58,7 +58,7 @@ func (k *Keycloak) LoginAdmin(accountId string, password string) (*domain.User, 
 
 func (k *Keycloak) Login(accountId string, password string, organizationId string) (*domain.User, error) {
 	ctx := context.Background()
-	JWTToken, err := k.client.Login(ctx, DefaultClientID, DefaultClientSecret, organizationId, accountId, password)
+	JWTToken, err := k.client.Login(ctx, DefaultClientID, k.config.ClientSecret, organizationId, accountId, password)
 	if err != nil {
 		log.Error(err)
 		return nil, err
@@ -109,7 +109,7 @@ func (k *Keycloak) InitializeKeycloak() error {
 
 	var redirectURIs []string
 	redirectURIs = append(redirectURIs, viper.GetString("external-address")+"/*")
-	tksClient, err := k.ensureClient(ctx, token, DefaultMasterRealm, DefaultClientID, DefaultClientSecret, &redirectURIs)
+	tksClient, err := k.ensureClient(ctx, token, DefaultMasterRealm, DefaultClientID, k.config.ClientSecret, &redirectURIs)
 	if err != nil {
 		log.Fatal(err)
 		return err
@@ -122,7 +122,7 @@ func (k *Keycloak) InitializeKeycloak() error {
 		}
 	}
 
-	adminCliClient, err := k.ensureClient(ctx, token, DefaultMasterRealm, AdminCliClientID, DefaultClientSecret, nil)
+	adminCliClient, err := k.ensureClient(ctx, token, DefaultMasterRealm, AdminCliClientID, k.config.ClientSecret, nil)
 	if err != nil {
 		log.Fatal(err)
 		return err
@@ -139,7 +139,7 @@ func (k *Keycloak) InitializeKeycloak() error {
 	_ = getRefreshTokenExpiredDuration(k.adminCliToken)
 	go func() {
 		for {
-			if token, err := k.client.RefreshToken(context.Background(), k.adminCliToken.RefreshToken, AdminCliClientID, DefaultClientSecret, DefaultMasterRealm); err != nil {
+			if token, err := k.client.RefreshToken(context.Background(), k.adminCliToken.RefreshToken, AdminCliClientID, k.config.ClientSecret, DefaultMasterRealm); err != nil {
 				log.Errorf("[Refresh]error is :%s(%T)", err.Error(), err)
 				log.Info("[Do Keycloak Admin CLI Login]")
 				k.adminCliToken, err = k.client.LoginAdmin(ctx, k.config.AdminId, k.config.AdminPassword, DefaultMasterRealm)
@@ -168,7 +168,7 @@ func (k *Keycloak) CreateRealm(organizationId string) (string, error) {
 
 	var redirectURIs []string
 	redirectURIs = append(redirectURIs, viper.GetString("external-address")+"/*")
-	clientUUID, err := k.createDefaultClient(context.Background(), token.AccessToken, organizationId, DefaultClientID, DefaultClientSecret, &redirectURIs)
+	clientUUID, err := k.createDefaultClient(context.Background(), token.AccessToken, organizationId, DefaultClientID, k.config.ClientSecret, &redirectURIs)
 	if err != nil {
 		log.Error(err, "createDefaultClient")
 		return "", err
@@ -366,7 +366,7 @@ func (k *Keycloak) DeleteUser(organizationId string, userAccountId string) error
 
 func (k *Keycloak) VerifyAccessToken(token string, organizationId string) error {
 	ctx := context.Background()
-	rptResult, err := k.client.RetrospectToken(ctx, token, DefaultClientID, DefaultClientSecret, organizationId)
+	rptResult, err := k.client.RetrospectToken(ctx, token, DefaultClientID, k.config.ClientSecret, organizationId)
 	if err != nil {
 		return err
 	}

--- a/internal/usecase/auth.go
+++ b/internal/usecase/auth.go
@@ -349,7 +349,7 @@ func makingCookie(organizationId, userName, password string) ([]*http.Cookie, er
 	baseUrl := viper.GetString("keycloak-address") + "/realms/" + organizationId + "/protocol/openid-connect"
 	var oauth2Config = &oauth2.Config{
 		ClientID:     keycloak.DefaultClientID,
-		ClientSecret: keycloak.DefaultClientSecret,
+		ClientSecret: viper.GetString("keycloak-client-secret"),
 		RedirectURL:  viper.GetString("external-address") + internal.API_PREFIX + internal.API_VERSION + "/auth/callback",
 		Scopes:       []string{"openid"},
 		Endpoint: oauth2.Endpoint{


### PR DESCRIPTION
개발 과정에서 에 대한 secret을 상수화 해서 사용하였으나, 운영을 위해 이를 tks-api 구동 시 받은 parameter를 사용하도록 수정.

tks-api 구동 시, keycloak-address, keycloak-admin, keycloak-password에 더불어 "keycloak-client-secret"에 대한 값을 parameter로 넣어야함.