### PR TITLE
trivial. increase max stage to 39 on creating lma.

### DIFF
--- a/pkg/domain/stack.go
+++ b/pkg/domain/stack.go
@@ -63,7 +63,7 @@ func (m StackStatus) FromString(s string) StackStatus {
 
 const MAX_STEP_CLUSTER_CREATE = 13
 const MAX_STEP_CLUSTER_REMOVE = 11
-const MAX_STEP_LMA_CREATE_PRIMARY = 36
+const MAX_STEP_LMA_CREATE_PRIMARY = 39
 const MAX_STEP_LMA_CREATE_MEMBER = 27
 const MAX_STEP_LMA_REMOVE = 11
 const MAX_STEP_SM_CREATE = 22


### PR DESCRIPTION
lma 의 최대 step 을 기존 36 에서 39로 변경합니다.

minor fix 이므로 issue 를 생성하지 않았습니다.