### PR TITLE
Pagination

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -4461,6 +4461,17 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.FilterResponse": {
+            "type": "object",
+            "properties": {
+                "column": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.FindIdRequest": {
             "type": "object",
             "required": [
@@ -4535,6 +4546,9 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/domain.AlertResponse"
                     }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/domain.PaginationResponse"
                 }
             }
         },
@@ -4995,6 +5009,35 @@ const docTemplate = `{
                 },
                 "updatedAt": {
                     "type": "string"
+                }
+            }
+        },
+        "domain.PaginationResponse": {
+            "type": "object",
+            "properties": {
+                "filters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.FilterResponse"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "sortColumn": {
+                    "type": "string"
+                },
+                "sortOrder": {
+                    "type": "string"
+                },
+                "totalPages": {
+                    "type": "integer"
+                },
+                "totalRows": {
+                    "type": "integer"
                 }
             }
         },

--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -855,6 +855,39 @@ const docTemplate = `{
                         "name": "organizationId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "limit",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "sortColumn",
+                        "name": "soertColumn",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "sortOrder",
+                        "name": "sortOrder",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "filters",
+                        "name": "filters",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -848,6 +848,39 @@
                         "name": "organizationId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "limit",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "sortColumn",
+                        "name": "soertColumn",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "sortOrder",
+                        "name": "sortOrder",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "filters",
+                        "name": "filters",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -4454,6 +4454,17 @@
                 }
             }
         },
+        "domain.FilterResponse": {
+            "type": "object",
+            "properties": {
+                "column": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.FindIdRequest": {
             "type": "object",
             "required": [
@@ -4528,6 +4539,9 @@
                     "items": {
                         "$ref": "#/definitions/domain.AlertResponse"
                     }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/domain.PaginationResponse"
                 }
             }
         },
@@ -4988,6 +5002,35 @@
                 },
                 "updatedAt": {
                     "type": "string"
+                }
+            }
+        },
+        "domain.PaginationResponse": {
+            "type": "object",
+            "properties": {
+                "filters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.FilterResponse"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "sortColumn": {
+                    "type": "string"
+                },
+                "sortOrder": {
+                    "type": "string"
+                },
+                "totalPages": {
+                    "type": "integer"
+                },
+                "totalRows": {
+                    "type": "integer"
                 }
             }
         },

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -2272,6 +2272,28 @@ paths:
         name: organizationId
         required: true
         type: string
+      - description: limit
+        in: query
+        name: limit
+        type: string
+      - description: page
+        in: query
+        name: page
+        type: string
+      - description: sortColumn
+        in: query
+        name: soertColumn
+        type: string
+      - description: sortOrder
+        in: query
+        name: sortOrder
+        type: string
+      - description: filters
+        in: query
+        items:
+          type: string
+        name: filters
+        type: array
       produces:
       - application/json
       responses:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -828,6 +828,13 @@ definitions:
     - accessKeyId
     - secretAccessKey
     type: object
+  domain.FilterResponse:
+    properties:
+      column:
+        type: string
+      value:
+        type: string
+    type: object
   domain.FindIdRequest:
     properties:
       code:
@@ -879,6 +886,8 @@ definitions:
         items:
           $ref: '#/definitions/domain.AlertResponse'
         type: array
+      pagination:
+        $ref: '#/definitions/domain.PaginationResponse'
     type: object
   domain.GetAppGroupResponse:
     properties:
@@ -1176,6 +1185,25 @@ definitions:
         type: string
       updatedAt:
         type: string
+    type: object
+  domain.PaginationResponse:
+    properties:
+      filters:
+        items:
+          $ref: '#/definitions/domain.FilterResponse'
+        type: array
+      limit:
+        type: integer
+      page:
+        type: integer
+      sortColumn:
+        type: string
+      sortOrder:
+        type: string
+      totalPages:
+        type: integer
+      totalRows:
+        type: integer
     type: object
   domain.Role:
     properties:

--- a/internal/delivery/http/alert.go
+++ b/internal/delivery/http/alert.go
@@ -77,6 +77,11 @@ func (h *AlertHandler) CreateAlert(w http.ResponseWriter, r *http.Request) {
 // @Accept json
 // @Produce json
 // @Param organizationId path string true "organizationId"
+// @Param limit query string false "limit"
+// @Param page query string false "page"
+// @Param soertColumn query string false "sortColumn"
+// @Param sortOrder query string false "sortOrder"
+// @Param filters query []string false "filters"
 // @Success 200 {object} domain.GetAlertsResponse
 // @Router /organizations/{organizationId}/alerts [get]
 // @Security     JWT

--- a/internal/pagination/pagination.go
+++ b/internal/pagination/pagination.go
@@ -1,0 +1,100 @@
+package pagination
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+)
+
+type Pagination struct {
+	Limit      int      `json:"limit"`
+	Page       int      `json:"page"`
+	SortColumn string   `json:"sortColumn"`
+	SortOrder  string   `json:"sortOrder" validate:"oneof=ASC asc DESC desc"`
+	Filters    []Filter `json:"filter,omitempty"`
+	TotalRows  int64    `json:"totalRows"`
+	TotalPages int      `json:"totalPages"`
+}
+
+type Filter struct {
+	Column string `json:"column"`
+	Value  string `json:"value"`
+}
+
+var DEFAULT_LIMIT = 10
+
+func (p *Pagination) GetOffset() int {
+	return (p.GetPage() - 1) * p.GetLimit()
+}
+
+func (p *Pagination) GetLimit() int {
+	if p.Limit == 0 {
+		p.Limit = DEFAULT_LIMIT
+	}
+	return p.Limit
+}
+
+func (p *Pagination) GetPage() int {
+	if p.Page == 0 {
+		p.Page = 1
+	}
+	return p.Page
+}
+
+func (p *Pagination) GetSortColumn() string {
+	return p.SortColumn
+}
+
+func (p *Pagination) GetSortOrder() string {
+	return p.SortOrder
+}
+
+func (p *Pagination) GetFilter() []Filter {
+	return p.Filters
+}
+
+/*
+	{
+		sortingColumn : "id",
+		order : "ASC",
+		page : 1,
+		limit : 10,
+	}
+*/
+func NewPagination(urlParams *url.Values) Pagination {
+	var pg Pagination
+
+	pg.SortColumn = urlParams.Get("sortColumn")
+	if pg.SortColumn == "" {
+		pg.SortColumn = "created_at"
+	}
+	pg.SortOrder = urlParams.Get("sortOrder")
+	if pg.SortOrder == "" {
+		pg.SortOrder = "ASC"
+	}
+
+	page := urlParams.Get("page")
+	if page == "" {
+		pg.Page = 1
+	} else {
+		pg.Page, _ = strconv.Atoi(page)
+	}
+
+	limit := urlParams.Get("limit")
+	if limit == "" {
+		pg.Limit = DEFAULT_LIMIT
+	} else {
+		limitNum, err := strconv.Atoi(limit)
+		if err == nil {
+			pg.Limit = limitNum
+		}
+	}
+
+	// [TODO] filter
+	filter := urlParams.Get("filter")
+	if filter != "" {
+		_ = json.Unmarshal([]byte(filter), &pg.Filters)
+	}
+
+	return pg
+}

--- a/internal/repository/alert.go
+++ b/internal/repository/alert.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"fmt"
+	"math"
 	"time"
 
 	"github.com/google/uuid"
@@ -8,14 +10,16 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
+	"github.com/openinfradev/tks-api/internal/pagination"
 	"github.com/openinfradev/tks-api/pkg/domain"
+	"github.com/openinfradev/tks-api/pkg/log"
 )
 
 // Interfaces
 type IAlertRepository interface {
 	Get(alertId uuid.UUID) (domain.Alert, error)
 	GetByName(organizationId string, name string) (domain.Alert, error)
-	Fetch(organizationId string) ([]domain.Alert, error)
+	Fetch(organizationId string, pg *pagination.Pagination) ([]domain.Alert, error)
 	FetchPodRestart(organizationId string, start time.Time, end time.Time) ([]domain.Alert, error)
 	Create(dto domain.Alert) (alertId uuid.UUID, err error)
 	Update(dto domain.Alert) (err error)
@@ -99,15 +103,51 @@ func (r *AlertRepository) GetByName(organizationId string, name string) (out dom
 	return
 }
 
-func (r *AlertRepository) Fetch(organizationId string) (out []domain.Alert, err error) {
+/*
+	var historiesWithUser []HistoryWithUser
+
+	var total int64
+	r.db.Find(&History{}, "project_id = '' OR project_id = ?", projectId).Count(&total)
+
+	pagination.TotalRows = total
+	pagination.TotalPages = int(math.Ceil(float64(total) / float64(pagination.Limit)))
+
+	log.Info(total)
+	log.Info(pagination.Limit)
+
+	res := r.db.Offset(pagination.GetOffset()).Limit(pagination.GetLimit()).Order(pagination.GetSort()).
+		Model(&History{}).
+		Select("histories.*, users.account_id").Joins("left join users on histories.user_id::text=users.id::text").Where("project_id = '' OR project_id = ?", projectId).
+		Scan(&historiesWithUser)
+
+	if res.RowsAffected == 0 || res.Error != nil {
+		return nil, fmt.Errorf("No history")
+	}
+
+*/
+
+func (r *AlertRepository) Fetch(organizationId string, pg *pagination.Pagination) (out []domain.Alert, err error) {
 	var alerts []Alert
-	res := r.db.Preload("AlertActions", func(db *gorm.DB) *gorm.DB {
-		return db.Order("created_at ASC")
-	}).Preload("AlertActions.Taker").
+	var total int64
+
+	// [TODO] filter
+	r.db.Find(&alerts, "organization_id = ?", organizationId).Count(&total)
+
+	pg.TotalRows = total
+	pg.TotalPages = int(math.Ceil(float64(total) / float64(pg.Limit)))
+
+	log.Info(total)
+	log.Info(pg.Limit)
+
+	orderQuery := fmt.Sprintf("%s %s", pg.SortColumn, pg.SortOrder)
+
+	res := r.db.Offset(pg.GetOffset()).Limit(pg.GetLimit()).Order(orderQuery).
+		Preload("AlertActions", func(db *gorm.DB) *gorm.DB {
+			return db.Order("created_at ASC")
+		}).Preload("AlertActions.Taker").
 		Preload("Cluster", "status = 2").
 		Preload("Organization").
 		Joins("join clusters on clusters.id = alerts.cluster_id AND clusters.status = 2").
-		Order("created_at desc").Limit(1000).
 		Find(&alerts, "alerts.organization_id = ?", organizationId)
 	if res.Error != nil {
 		return nil, res.Error

--- a/internal/usecase/alert.go
+++ b/internal/usecase/alert.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openinfradev/tks-api/internal/middleware/auth/request"
 
 	"github.com/google/uuid"
+	"github.com/openinfradev/tks-api/internal/pagination"
 	"github.com/openinfradev/tks-api/internal/repository"
 	"github.com/openinfradev/tks-api/pkg/domain"
 	"github.com/openinfradev/tks-api/pkg/httpErrors"
@@ -21,7 +22,7 @@ import (
 type IAlertUsecase interface {
 	Get(ctx context.Context, alertId uuid.UUID) (domain.Alert, error)
 	GetByName(ctx context.Context, organizationId string, name string) (domain.Alert, error)
-	Fetch(ctx context.Context, organizationId string) ([]domain.Alert, error)
+	Fetch(ctx context.Context, organizationId string, pg *pagination.Pagination) ([]domain.Alert, error)
 	Create(ctx context.Context, dto domain.CreateAlertRequest) (err error)
 	Update(ctx context.Context, dto domain.Alert) error
 	Delete(ctx context.Context, dto domain.Alert) error
@@ -149,8 +150,8 @@ func (u *AlertUsecase) GetByName(ctx context.Context, organizationId string, nam
 	return
 }
 
-func (u *AlertUsecase) Fetch(ctx context.Context, organizationId string) (alerts []domain.Alert, err error) {
-	alerts, err = u.repo.Fetch(organizationId)
+func (u *AlertUsecase) Fetch(ctx context.Context, organizationId string, pg *pagination.Pagination) (alerts []domain.Alert, err error) {
+	alerts, err = u.repo.Fetch(organizationId, pg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/alert.go
+++ b/pkg/domain/alert.go
@@ -155,7 +155,8 @@ type AlertActionResponse struct {
 }
 
 type GetAlertsResponse struct {
-	Alerts []AlertResponse `json:"alerts"`
+	Alerts     []AlertResponse    `json:"alerts"`
+	Pagination PaginationResponse `json:"pagination"`
 }
 
 type GetAlertResponse struct {

--- a/pkg/domain/pagination.go
+++ b/pkg/domain/pagination.go
@@ -1,0 +1,16 @@
+package domain
+
+type PaginationResponse struct {
+	Limit      int              `json:"limit"`
+	Page       int              `json:"page"`
+	SortColumn string           `json:"sortColumn"`
+	SortOrder  string           `json:"sortOrder"`
+	Filters    []FilterResponse `json:"filters,omitempty"`
+	TotalRows  int64            `json:"totalRows"`
+	TotalPages int              `json:"totalPages"`
+}
+
+type FilterResponse struct {
+	Column string `json:"column"`
+	Value  string `json:"value"`
+}


### PR DESCRIPTION
pagination 처리 로직 추가하였습니다. 
서버<>클라 인터페이스를 맞추기 위한 PR 입니다

일단
 . alerts 쪽만 적용하였습니다.
 . filter 는 적용하지 않았습니다.
 . sortColumn 은 어떤 방식으로 전달하는 것이 좋을지 논의가 필요합니다.

@Siyeop 
swagger 에 query string 추가하였는데, 아래와 같이 호출하시면 되겠습니다.
 . {{URL}}/api/1.0/organizations/{{ORGANIZATION_ID}}/alerts?limit=5&page=1&sortOrder=DESC&sortColumn=created_at
json scheme 은 좋은 명명 있으시면 안내바랍니다.
