### PR TITLE
app-serving: add preprocessing for extraEnv param

### DIFF
--- a/internal/usecase/app-serve-app.go
+++ b/internal/usecase/app-serve-app.go
@@ -1,8 +1,8 @@
 package usecase
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
 
 	"strconv"
 	"strings"
@@ -94,7 +94,11 @@ func (u *AppServeAppUsecase) CreateAppServeApp(app *domain.AppServeApp) (string,
 	log.Debug("extraEnv received: ", extEnv)
 
 	tempMap := map[string]string{}
-	json.Unmarshal([]byte(extEnv), &tempMap)
+	err := json.Unmarshal([]byte(extEnv), &tempMap)
+	if err != nil {
+		log.Error(err)
+		return "", "", errors.Wrap(err, "Failed to process extraEnv param.")
+	}
 	log.Debugf("extraEnv marshalled: %v", tempMap)
 
 	newExtEnv := map[string]string{}


### PR DESCRIPTION
tks-console로부터 전달받은 extraEnv string을 Argo-WF로 그대로 전달시 따옴표(")가 유실되므로, escape 문자 덧붙여서 전달하도록 함.

tks-issues-753