### PR TITLE
bugfix: assign transformed extraEnv to existing var

### DIFF
--- a/internal/usecase/app-serve-app.go
+++ b/internal/usecase/app-serve-app.go
@@ -110,7 +110,7 @@ func (u *AppServeAppUsecase) CreateAppServeApp(app *domain.AppServeApp) (string,
 		}
 
 		mJson, _ := json.Marshal(newExtEnv)
-		extEnv := string(mJson)
+		extEnv = string(mJson)
 		log.Debug("After transform, extraEnv: ", extEnv)
 	}
 
@@ -401,7 +401,6 @@ func (u *AppServeAppUsecase) UpdateAppServeApp(app *domain.AppServeApp, appTask 
 
 		mJson, _ := json.Marshal(newExtEnv)
 		extEnv = string(mJson)
-
 		log.Debug("After transform, extraEnv: ", extEnv)
 	}
 


### PR DESCRIPTION
Fixes https://github.com/openinfradev/tks-issues/issues/796

한참 디버깅했더니 ':'(콜론) 하나 잘못 넣은게 원인이었네요ㅠ