### PR TITLE
app-serving: remove redundant connect button

### DIFF
--- a/internal/delivery/http/app-serve-app.go
+++ b/internal/delivery/http/app-serve-app.go
@@ -450,22 +450,8 @@ func makeStage(app *domain.AppServeApp, pl string) domain.StageResponse {
 
 	var actions []domain.ActionResponse
 	if stage.Status == "DEPLOY_SUCCESS" {
-		if strategy == "rolling-update" {
-			action := domain.ActionResponse{
-				Name: "ENDPOINT",
-				Uri:  app.EndpointUrl,
-				Type: "LINK",
-			}
-			actions = append(actions, action)
-		} else if strategy == "blue-green" {
-			if taskStatus == "PROMOTE_SUCCESS" || taskStatus == "ABORT_SUCCESS" {
-				action := domain.ActionResponse{
-					Name: "ENDPOINT",
-					Uri:  app.EndpointUrl,
-					Type: "LINK",
-				}
-				actions = append(actions, action)
-			} else if taskStatus == "PROMOTE_WAIT" {
+		if strategy == "blue-green" {
+			if taskStatus == "PROMOTE_WAIT" {
 				action := domain.ActionResponse{
 					Name: "OLD_EP",
 					Uri:  app.EndpointUrl,


### PR DESCRIPTION
블루/그린 선택 완료 후에도 '배포' 단계의 박스에 '앱 접속' 버튼이 나오는 점이 사용자에게 혼동을 줄 수 있어 불필요한 버튼 삭제합니다. (메타 영역에 '앱 접속' 버튼이 있어 중복임)