### PR TITLE
bug fix: change sso_session_idle_timeout time 8hours -> 1day

### DIFF
--- a/internal/keycloak/config.go
+++ b/internal/keycloak/config.go
@@ -13,6 +13,6 @@ const (
 	DefaultClientSecret   = "secret"
 	AdminCliClientID      = "admin-cli"
 	accessTokenLifespan   = 60 * 60 * 24 // 1 day
-	ssoSessionIdleTimeout = 60 * 60 * 8  // 8 hours
+	ssoSessionIdleTimeout = 60 * 60 * 24 // 1 day
 	ssoSessionMaxLifespan = 60 * 60 * 24 // 1 day
 )


### PR DESCRIPTION
버그 내용: TKS-Console login 후 grafana sso가 되지 않던 이슈
수정 내용: accesstoken 시간과 SSO idle timeout 시간을 동일하게 변경