### PR TITLE
add Grafana URL to appserving DTO

### DIFF
--- a/internal/usecase/app-serve-app.go
+++ b/internal/usecase/app-serve-app.go
@@ -49,8 +49,10 @@ type AppServeAppUsecase struct {
 
 func NewAppServeAppUsecase(r repository.Repository, argoClient argowf.ArgoClient) IAppServeAppUsecase {
 	return &AppServeAppUsecase{
-		repo: r.AppServeApp,
-		argo: argoClient,
+		repo:             r.AppServeApp,
+		organizationRepo: r.Organization,
+		appGroupRepo:     r.AppGroup,
+		argo:             argoClient,
 	}
 }
 

--- a/internal/usecase/app-serve-app.go
+++ b/internal/usecase/app-serve-app.go
@@ -212,7 +212,7 @@ func (u *AppServeAppUsecase) GetAppServeAppById(appId string) (*domain.AppServeA
 				return asa, err
 			}
 			if len(applications) > 0 {
-				asa.GrafanaUrl = applications[0].Endpoint + "/d/tks_container_dashboard/tks-kubernetes-view-container?refresh=30s&var-cluster=" + asa.TargetClusterId + "&var-kubernetes_namespace_name=" + asa.Namespace + "&var-kubernetes_pod_name=All&var-kubernetes_container_name=main&var-TopK=10"
+				asa.GrafanaUrl = applications[0].Endpoint + "/d/tks_appserving_dashboard/tks-appserving-dashboard?refresh=30s&var-cluster=" + asa.TargetClusterId + "&var-kubernetes_namespace_name=" + asa.Namespace + "&var-kubernetes_pod_name=All&var-kubernetes_container_name=main&var-TopK=10"
 			}
 		}
 	}

--- a/internal/usecase/app-serve-app.go
+++ b/internal/usecase/app-serve-app.go
@@ -195,7 +195,7 @@ func (u *AppServeAppUsecase) GetAppServeAppById(appId string) (*domain.AppServeA
 	************************/
 	organization, err := u.organizationRepo.Get(asa.OrganizationId)
 	if err != nil {
-		return out, httpErrors.NewInternalServerError(errors.Wrap(err, fmt.Sprintf("Failed to get organization for app %s", asa.Name)), "S_FAILED_FETCH_ORGANIZATION", "")
+		return asa, httpErrors.NewInternalServerError(errors.Wrap(err, fmt.Sprintf("Failed to get organization for app %s", asa.Name)), "S_FAILED_FETCH_ORGANIZATION", "")
 	}
 
 	appGroupsInPrimaryCluster, err := u.appGroupRepo.Fetch(domain.ClusterId(organization.PrimaryClusterId), nil)

--- a/internal/usecase/stack.go
+++ b/internal/usecase/stack.go
@@ -333,7 +333,7 @@ func (u *StackUsecase) Get(ctx context.Context, stackId domain.StackId) (out dom
 
 	organization, err := u.organizationRepo.Get(cluster.OrganizationId)
 	if err != nil {
-		return out, httpErrors.NewInternalServerError(errors.Wrap(err, fmt.Sprintf("Failed to get organization for clusterId %s", cluster.OrganizationId)), "S_FAILED_FETCH_ORGANIZATION", "")
+		return out, httpErrors.NewInternalServerError(errors.Wrap(err, fmt.Sprintf("Failed to get organization for clusterId %s", domain.ClusterId(stackId))), "S_FAILED_FETCH_ORGANIZATION", "")
 	}
 
 	appGroups, err := u.appGroupRepo.Fetch(domain.ClusterId(stackId), nil)

--- a/pkg/domain/app-serve-app.go
+++ b/pkg/domain/app-serve-app.go
@@ -19,6 +19,7 @@ type AppServeApp struct {
 	TargetClusterId    string            `json:"targetClusterId,omitempty"`                // target cluster to which the app is deployed
 	TargetClusterName  string            `gorm:"-:all" json:"targetClusterName,omitempty"` // target cluster name
 	Status             string            `gorm:"index" json:"status,omitempty"`            // status is status of deployed app
+	GrafanaUrl         string            `json:"grafanaUrl,omitempty"`                     // grafana dashboard URL for deployed app
 	CreatedAt          time.Time         `gorm:"autoCreateTime:false" json:"createdAt" `
 	UpdatedAt          *time.Time        `gorm:"autoUpdateTime:false" json:"updatedAt"`
 	DeletedAt          *time.Time        `json:"deletedAt"`


### PR DESCRIPTION
https://github.com/openinfradev/tks-issues/issues/789

새로 추가된 앱서빙 대시보드 URL을 DTO 객체에 포함하여 tks-console에서 GET API로 조회 가능하도록 함
(stack 화면의 대시보드 바로가기 버튼과 동일 로직)