### PR TITLE
trivial. workarround fix for aws creation

### DIFF
--- a/internal/usecase/stack.go
+++ b/internal/usecase/stack.go
@@ -72,7 +72,7 @@ func (u *StackUsecase) Create(ctx context.Context, dto domain.Stack) (stackId do
 		return "", httpErrors.NewBadRequestError(httpErrors.DuplicateResource, "S_CREATE_ALREADY_EXISTED_NAME", "")
 	}
 
-	_, err = u.stackTemplateRepo.Get(dto.StackTemplateId)
+	stackTemplate, err := u.stackTemplateRepo.Get(dto.StackTemplateId)
 	if err != nil {
 		return "", httpErrors.NewInternalServerError(errors.Wrap(err, "Invalid stackTemplateId"), "S_INVALID_STACK_TEMPLATE", "")
 	}
@@ -105,6 +105,13 @@ func (u *StackUsecase) Create(ctx context.Context, dto domain.Stack) (stackId do
 	var stackConf domain.StackConfResponse
 	if err = domain.Map(dto.Conf, &stackConf); err != nil {
 		log.InfoWithContext(ctx, err)
+	}
+	if stackTemplate.CloudService == "AWS" && stackTemplate.KubeType == "AWS" {
+		if stackConf.TksCpNode == 0 {
+			stackConf.TksCpNode = 3
+			stackConf.TksCpNodeMax = 3
+
+		}
 	}
 
 	workflow := "tks-stack-create"


### PR DESCRIPTION
EKS 가 아닌 AWS 일 경우 현재는 UI 에서 control-plane 개수를 입력받는 곳이 없습니다. ( 현재 aws-standard 는 spec-out 상태 )
btv 테스트를 위해 aws 타입의 경우, tks-cp-node default 값을 3개로 변경합니다.

aws-standard 설치의 ui 기획/설계 이후에 재 구현되어야 하는 부분입니다.