### PR TITLE
feature. generate clusterId to tks-admin when import admin cluster

### DIFF
--- a/internal/helper/id.go
+++ b/internal/helper/id.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	TKS_ADMIN                   = "tks-admin"
 	PREFIX_USER_ID              = "u"
 	PREFIX_CLUSTER_ID           = "c"
 	PREFIX_ORGANIZATION_ID      = "o"
@@ -29,6 +30,9 @@ func GenerateApplicaionGroupId() string {
 }
 
 func ValidateClusterId(id string) bool {
+	if id == TKS_ADMIN {
+		return true
+	}
 	if !strings.HasPrefix(id, PREFIX_CLUSTER_ID) {
 		return false
 	}

--- a/internal/repository/cluster.go
+++ b/internal/repository/cluster.go
@@ -83,11 +83,6 @@ type Cluster struct {
 	Updator                User       `gorm:"foreignKey:UpdatorId"`
 }
 
-func (c *Cluster) BeforeCreate(tx *gorm.DB) (err error) {
-	c.ID = domain.ClusterId(helper.GenerateClusterId())
-	return nil
-}
-
 type ClusterFavorite struct {
 	gorm.Model
 
@@ -219,6 +214,7 @@ func (r *ClusterRepository) Create(dto domain.Cluster) (clusterId domain.Cluster
 		cloudAccountId = nil
 	}
 	cluster := Cluster{
+		ID:                     domain.ClusterId(helper.GenerateClusterId()),
 		OrganizationId:         dto.OrganizationId,
 		Name:                   dto.Name,
 		Description:            dto.Description,
@@ -242,6 +238,10 @@ func (r *ClusterRepository) Create(dto domain.Cluster) (clusterId domain.Cluster
 		TksUserNodeMax:         dto.Conf.TksUserNodeMax,
 		TksUserNodeType:        dto.Conf.TksUserNodeType,
 	}
+	if dto.ID != "" {
+		cluster.ID = dto.ID
+	}
+
 	res := r.db.Create(&cluster)
 	if res.Error != nil {
 		log.Error(res.Error)

--- a/internal/usecase/cluster.go
+++ b/internal/usecase/cluster.go
@@ -237,6 +237,10 @@ func (u *ClusterUsecase) Import(ctx context.Context, dto domain.Cluster) (cluste
 
 	userId := user.GetUserId()
 	dto.CreatorId = &userId
+	if dto.ClusterType == domain.ClusterType_ADMIN {
+		dto.ID = "tks-admin"
+		dto.Name = "tks-admin"
+	}
 	clusterId, err = u.repo.Create(dto)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to create cluster")


### PR DESCRIPTION
admin cluster 를 import 할때 clusterId 를  "tks-admin" 으로 부여합니다.
randomvalue 의 경우는 argocd cluster 등록시 문제가 발생합니다.

workaround 성 fix 이며, 추후 admin cluster import 에 대한 설계시 고려되어야 하는 부분입니다.