### PR TITLE
add manage tks admin user logic

### DIFF
--- a/internal/delivery/http/permission.go
+++ b/internal/delivery/http/permission.go
@@ -26,6 +26,7 @@ func NewPermissionHandler(usecase usecase.Usecase) *PermissionHandler {
 }
 
 // GetPermissionTemplates godoc
+//
 //	@Tags			Permission
 //	@Summary		Get Permission Templates
 //	@Description	Get Permission Templates
@@ -34,7 +35,6 @@ func NewPermissionHandler(usecase usecase.Usecase) *PermissionHandler {
 //	@Success		200	{object}	domain.PermissionSet
 //	@Router			/permissions/templates [get]
 //	@Security		JWT
-
 func (h PermissionHandler) GetPermissionTemplates(w http.ResponseWriter, r *http.Request) {
 	permissionSet := domain.NewDefaultPermissionSet()
 
@@ -50,6 +50,7 @@ func (h PermissionHandler) GetPermissionTemplates(w http.ResponseWriter, r *http
 }
 
 // GetPermissionsByRoleId godoc
+//
 //	@Tags			Permission
 //	@Summary		Get Permissions By Role ID
 //	@Description	Get Permissions By Role ID
@@ -58,7 +59,6 @@ func (h PermissionHandler) GetPermissionTemplates(w http.ResponseWriter, r *http
 //	@Success		200	{object}	domain.PermissionSet
 //	@Router			organizations/{organizationId}/roles/{roleId}/permissions [get]
 //	@Security		JWT
-
 func (h PermissionHandler) GetPermissionsByRoleId(w http.ResponseWriter, r *http.Request) {
 	// path parameter
 	var roleId string
@@ -89,6 +89,7 @@ func (h PermissionHandler) GetPermissionsByRoleId(w http.ResponseWriter, r *http
 }
 
 // UpdatePermissionsByRoleId godoc
+//
 //	@Tags			Permission
 //	@Summary		Update Permissions By Role ID
 //	@Description	Update Permissions By Role ID
@@ -99,7 +100,6 @@ func (h PermissionHandler) GetPermissionsByRoleId(w http.ResponseWriter, r *http
 //	@Success		200
 //	@Router			organizations/{organizationId}/roles/{roleId}/permissions [put]
 //	@Security		JWT
-
 func (h PermissionHandler) UpdatePermissionsByRoleId(w http.ResponseWriter, r *http.Request) {
 	// path parameter
 	log.Debug("UpdatePermissionsByRoleId Called")

--- a/internal/delivery/http/role.go
+++ b/internal/delivery/http/role.go
@@ -35,6 +35,7 @@ func NewRoleHandler(usecase usecase.Usecase) *RoleHandler {
 }
 
 // CreateTksRole godoc
+//
 //	@Tags			Role
 //	@Summary		Create Tks Role
 //	@Description	Create Tks Role
@@ -45,7 +46,6 @@ func NewRoleHandler(usecase usecase.Usecase) *RoleHandler {
 //	@Success		200				{object}	domain.CreateTksRoleResponse
 //	@Router			/organizations/{organizationId}/roles [post]
 //	@Security		JWT
-
 func (h RoleHandler) CreateTksRole(w http.ResponseWriter, r *http.Request) {
 	// path parameter
 	var organizationId string
@@ -95,6 +95,7 @@ func (h RoleHandler) CreateTksRole(w http.ResponseWriter, r *http.Request) {
 }
 
 // ListTksRoles godoc
+//
 //	@Tags			Role
 //	@Summary		List Tks Roles
 //	@Description	List Tks Roles
@@ -103,7 +104,6 @@ func (h RoleHandler) CreateTksRole(w http.ResponseWriter, r *http.Request) {
 //	@Success		200				{object}	domain.ListTksRoleResponse
 //	@Router			/organizations/{organizationId}/roles [get]
 //	@Security		JWT
-
 func (h RoleHandler) ListTksRoles(w http.ResponseWriter, r *http.Request) {
 	// path parameter
 	var organizationId string
@@ -150,6 +150,7 @@ func (h RoleHandler) ListTksRoles(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetTksRole godoc
+//
 //	@Tags			Role
 //	@Summary		Get Tks Role
 //	@Description	Get Tks Role
@@ -159,7 +160,6 @@ func (h RoleHandler) ListTksRoles(w http.ResponseWriter, r *http.Request) {
 //	@Success		200				{object}	domain.GetTksRoleResponse
 //	@Router			/organizations/{organizationId}/roles/{roleId} [get]
 //	@Security		JWT
-
 func (h RoleHandler) GetTksRole(w http.ResponseWriter, r *http.Request) {
 	// path parameter
 	vars := mux.Vars(r)
@@ -192,6 +192,7 @@ func (h RoleHandler) GetTksRole(w http.ResponseWriter, r *http.Request) {
 }
 
 // DeleteTksRole godoc
+//
 //	@Tags			Role
 //	@Summary		Delete Tks Role
 //	@Description	Delete Tks Role
@@ -201,7 +202,6 @@ func (h RoleHandler) GetTksRole(w http.ResponseWriter, r *http.Request) {
 //	@Success		200
 //	@Router			/organizations/{organizationId}/roles/{roleId} [delete]
 //	@Security		JWT
-
 func (h RoleHandler) DeleteTksRole(w http.ResponseWriter, r *http.Request) {
 	// path parameter
 	vars := mux.Vars(r)
@@ -224,6 +224,7 @@ func (h RoleHandler) DeleteTksRole(w http.ResponseWriter, r *http.Request) {
 }
 
 // UpdateTksRole godoc
+//
 //	@Tags			Role
 //	@Summary		Update Tks Role
 //	@Description	Update Tks Role
@@ -235,7 +236,6 @@ func (h RoleHandler) DeleteTksRole(w http.ResponseWriter, r *http.Request) {
 //	@Success		200
 //	@Router			/organizations/{organizationId}/roles/{roleId} [put]
 //	@Security		JWT
-
 func (h RoleHandler) UpdateTksRole(w http.ResponseWriter, r *http.Request) {
 	// path parameter
 	vars := mux.Vars(r)
@@ -272,6 +272,7 @@ func (h RoleHandler) UpdateTksRole(w http.ResponseWriter, r *http.Request) {
 }
 
 // Admin_ListTksRoles godoc
+//
 //	@Tags			Role
 //	@Summary		Admin List Tks Roles
 //	@Description	Admin List Tks Roles
@@ -279,7 +280,6 @@ func (h RoleHandler) UpdateTksRole(w http.ResponseWriter, r *http.Request) {
 //	@Param			organizationId	path		string	true	"Organization ID"
 //	@Success		200				{object}	domain.ListTksRoleResponse
 //	@Router			/admin/organizations/{organizationId}/roles [get]
-
 func (h RoleHandler) Admin_ListTksRoles(w http.ResponseWriter, r *http.Request) {
 	// Same as ListTksRoles
 
@@ -327,6 +327,7 @@ func (h RoleHandler) Admin_ListTksRoles(w http.ResponseWriter, r *http.Request) 
 }
 
 // Admin_GetTksRole godoc
+//
 //	@Tags			Role
 //	@Summary		Admin Get Tks Role
 //	@Description	Admin Get Tks Role
@@ -335,7 +336,6 @@ func (h RoleHandler) Admin_ListTksRoles(w http.ResponseWriter, r *http.Request) 
 //	@Param			roleId			path		string	true	"Role ID"
 //	@Success		200				{object}	domain.GetTksRoleResponse
 //	@Router			/admin/organizations/{organizationId}/roles/{roleId} [get]
-
 func (h RoleHandler) Admin_GetTksRole(w http.ResponseWriter, r *http.Request) {
 	// Same as GetTksRole
 

--- a/pkg/domain/admin/user.go
+++ b/pkg/domain/admin/user.go
@@ -12,7 +12,7 @@ type CreateUserRequest struct {
 	Role          string `json:"role" validate:"required"`
 	Department    string `json:"department" validate:"min=0,max=50"`
 	Description   string `json:"description" validate:"min=0,max=100"`
-	AdminPassword string `json:"adminPassword" validate:"required"`
+	AdminPassword string `json:"adminPassword"`
 }
 
 type CreateUserResponse struct {
@@ -46,7 +46,7 @@ type UpdateUserRequest struct {
 	Department    string `json:"department" validate:"min=0,max=50"`
 	Role          string `json:"role" validate:"required"`
 	Description   string `json:"description" validate:"min=0,max=100"`
-	AdminPassword string `json:"adminPassword" validate:"required"`
+	AdminPassword string `json:"adminPassword"`
 }
 
 type UpdateUserResponse struct {
@@ -65,5 +65,5 @@ type UpdateUserResponse struct {
 }
 
 type DeleteUserRequest struct {
-	AdminPassword string `json:"adminPassword" validate:"required"`
+	AdminPassword string `json:"adminPassword"`
 }


### PR DESCRIPTION
TKS 관리자 생성/삭제/수정 API의 경우 관리자 포털의 "사용자" API와 동일한 API를 호출한다.
다만, "사용자" API와의 차이점은 두가지로,
1. request Body에 AdminPassword를 넣지 않거나 "" 으로 하며 
2. Path variable의 organization Id는 반드시 "master"로 한다.