### PR TITLE
User에 대한 Permission 리스트 출력 API 개발

### DIFF
--- a/internal/delivery/api/endpoint.go
+++ b/internal/delivery/api/endpoint.go
@@ -195,6 +195,7 @@ const (
 	GetPermissionTemplates
 	GetPermissionsByRoleId
 	UpdatePermissionsByRoleId
+	GetPermissionsByAccountId
 
 	// Admin_User
 	Admin_CreateUser

--- a/internal/delivery/api/endpoint.go
+++ b/internal/delivery/api/endpoint.go
@@ -19,7 +19,6 @@ const (
 	VerifyIdentityForLostId
 	VerifyIdentityForLostPassword
 	VerifyToken
-	DeleteToken
 
 	// User
 	CreateUser

--- a/internal/delivery/api/endpoints_permission_test.go
+++ b/internal/delivery/api/endpoints_permission_test.go
@@ -24,7 +24,7 @@ func TestEndpointsUsage(t *testing.T) {
 		ps.Configuration,
 		ps.ProjectManagement,
 		ps.Stack,
-		ps.SecurityPolicy,
+		ps.Policy,
 		ps.Common,
 		ps.Admin,
 	}

--- a/internal/delivery/api/endpoints_permission_test.go
+++ b/internal/delivery/api/endpoints_permission_test.go
@@ -1,0 +1,70 @@
+package api_test
+
+import (
+	"github.com/openinfradev/tks-api/internal/delivery/api"
+	"github.com/openinfradev/tks-api/internal/model"
+	"testing"
+)
+
+func TestEndpointsUsage(t *testing.T) {
+	var allEndpoints []string
+	for _, v := range api.ApiMap {
+		allEndpoints = append(allEndpoints, v.Name)
+	}
+	//allEndpoints := []Endpoint{
+	//	Login, Logout, RefreshToken, FindId, // 계속해서 모든 Endpoint 추가
+	//	// 나머지 Endpoint 상수들을 여기에 추가
+	//}
+	usageCount := make(map[string]int)
+	ps := model.NewAdminPermissionSet()
+
+	permissions := []*model.Permission{
+		ps.Dashboard,
+		ps.Notification,
+		ps.Configuration,
+		ps.ProjectManagement,
+		ps.Stack,
+		ps.SecurityPolicy,
+		ps.Common,
+		ps.Admin,
+	}
+
+	leafPermissions := make([]*model.Permission, 0)
+
+	for _, perm := range permissions {
+		leafPermissions = model.GetEdgePermission(perm, leafPermissions, nil)
+	}
+
+	// Permission 설정에서 Endpoint 사용 횟수 카운트
+	for _, perm := range leafPermissions {
+		countEndpoints(perm, usageCount)
+	}
+
+	var unusedEndpoints, duplicatedEndpoints []string
+
+	// 미사용 또는 중복 사용된 Endpoint 확인 및 출력
+	for _, endpoint := range allEndpoints {
+		count, exists := usageCount[endpoint]
+		if !exists {
+			unusedEndpoints = append(unusedEndpoints, endpoint)
+		} else if count > 1 {
+			duplicatedEndpoints = append(duplicatedEndpoints, endpoint)
+		}
+	}
+
+	for _, endpoint := range unusedEndpoints {
+		t.Logf("Unused Endpoint: %s", endpoint)
+	}
+
+	t.Logf("\n")
+	for _, endpoint := range duplicatedEndpoints {
+		t.Logf("Duplicated Endpoint: %s", endpoint)
+	}
+
+}
+
+func countEndpoints(perm *model.Permission, usageCount map[string]int) {
+	for _, endpoint := range perm.Endpoints {
+		usageCount[endpoint.Name]++
+	}
+}

--- a/internal/delivery/api/generated_endpoints.go.go
+++ b/internal/delivery/api/generated_endpoints.go.go
@@ -35,6 +35,10 @@ var ApiMap = map[Endpoint]EndpointInfo{
 		Name: "VerifyToken", 
 		Group: "Auth",
 	},
+    DeleteToken: {
+		Name: "DeleteToken", 
+		Group: "Auth",
+	},
     CreateUser: {
 		Name: "CreateUser", 
 		Group: "User",
@@ -599,6 +603,10 @@ var ApiMap = map[Endpoint]EndpointInfo{
 		Name: "UpdatePermissionsByRoleId", 
 		Group: "Permission",
 	},
+    GetPermissionsByAccountId: {
+		Name: "GetPermissionsByAccountId", 
+		Group: "Permission",
+	},
     Admin_CreateUser: {
 		Name: "Admin_CreateUser", 
 		Group: "Admin_User",
@@ -822,6 +830,8 @@ func (e Endpoint) String() string {
 		return "VerifyIdentityForLostPassword"
 	case VerifyToken:
 		return "VerifyToken"
+	case DeleteToken:
+		return "DeleteToken"
 	case CreateUser:
 		return "CreateUser"
 	case ListUser:
@@ -1104,6 +1114,8 @@ func (e Endpoint) String() string {
 		return "GetPermissionsByRoleId"
 	case UpdatePermissionsByRoleId:
 		return "UpdatePermissionsByRoleId"
+	case GetPermissionsByAccountId:
+		return "GetPermissionsByAccountId"
 	case Admin_CreateUser:
 		return "Admin_CreateUser"
 	case Admin_ListUser:
@@ -1228,6 +1240,8 @@ func GetEndpoint(name string) Endpoint {
 		return VerifyIdentityForLostPassword
 	case "VerifyToken":
 		return VerifyToken
+	case "DeleteToken":
+		return DeleteToken
 	case "CreateUser":
 		return CreateUser
 	case "ListUser":
@@ -1510,6 +1524,8 @@ func GetEndpoint(name string) Endpoint {
 		return GetPermissionsByRoleId
 	case "UpdatePermissionsByRoleId":
 		return UpdatePermissionsByRoleId
+	case "GetPermissionsByAccountId":
+		return GetPermissionsByAccountId
 	case "Admin_CreateUser":
 		return Admin_CreateUser
 	case "Admin_ListUser":

--- a/internal/delivery/api/generated_endpoints.go.go
+++ b/internal/delivery/api/generated_endpoints.go.go
@@ -35,10 +35,6 @@ var ApiMap = map[Endpoint]EndpointInfo{
 		Name: "VerifyToken", 
 		Group: "Auth",
 	},
-    DeleteToken: {
-		Name: "DeleteToken", 
-		Group: "Auth",
-	},
     CreateUser: {
 		Name: "CreateUser", 
 		Group: "User",
@@ -830,8 +826,6 @@ func (e Endpoint) String() string {
 		return "VerifyIdentityForLostPassword"
 	case VerifyToken:
 		return "VerifyToken"
-	case DeleteToken:
-		return "DeleteToken"
 	case CreateUser:
 		return "CreateUser"
 	case ListUser:
@@ -1240,8 +1234,6 @@ func GetEndpoint(name string) Endpoint {
 		return VerifyIdentityForLostPassword
 	case "VerifyToken":
 		return VerifyToken
-	case "DeleteToken":
-		return DeleteToken
 	case "CreateUser":
 		return CreateUser
 	case "ListUser":

--- a/internal/delivery/api/generated_endpoints.go.go
+++ b/internal/delivery/api/generated_endpoints.go.go
@@ -35,10 +35,6 @@ var ApiMap = map[Endpoint]EndpointInfo{
 		Name: "VerifyToken", 
 		Group: "Auth",
 	},
-    DeleteToken: {
-		Name: "DeleteToken", 
-		Group: "Auth",
-	},
     CreateUser: {
 		Name: "CreateUser", 
 		Group: "User",
@@ -826,8 +822,6 @@ func (e Endpoint) String() string {
 		return "VerifyIdentityForLostPassword"
 	case VerifyToken:
 		return "VerifyToken"
-	case DeleteToken:
-		return "DeleteToken"
 	case CreateUser:
 		return "CreateUser"
 	case ListUser:
@@ -1234,8 +1228,6 @@ func GetEndpoint(name string) Endpoint {
 		return VerifyIdentityForLostPassword
 	case "VerifyToken":
 		return VerifyToken
-	case "DeleteToken":
-		return DeleteToken
 	case "CreateUser":
 		return CreateUser
 	case "ListUser":

--- a/internal/delivery/http/permission.go
+++ b/internal/delivery/http/permission.go
@@ -1,15 +1,14 @@
 package http
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/gorilla/mux"
 	"github.com/openinfradev/tks-api/internal/model"
-	"github.com/openinfradev/tks-api/internal/serializer"
 	"github.com/openinfradev/tks-api/internal/usecase"
 	"github.com/openinfradev/tks-api/pkg/domain"
 	"github.com/openinfradev/tks-api/pkg/httpErrors"
-	"github.com/openinfradev/tks-api/pkg/log"
 )
 
 type IPermissionHandler interface {
@@ -20,11 +19,13 @@ type IPermissionHandler interface {
 
 type PermissionHandler struct {
 	permissionUsecase usecase.IPermissionUsecase
+	userUsecase       usecase.IUserUsecase
 }
 
 func NewPermissionHandler(usecase usecase.Usecase) *PermissionHandler {
 	return &PermissionHandler{
 		permissionUsecase: usecase.Permission,
+		userUsecase:       usecase.User,
 	}
 }
 
@@ -41,20 +42,110 @@ func NewPermissionHandler(usecase usecase.Usecase) *PermissionHandler {
 func (h PermissionHandler) GetPermissionTemplates(w http.ResponseWriter, r *http.Request) {
 	permissionSet := model.NewDefaultPermissionSet()
 
-	var premissionSetResponse domain.PermissionSetResponse
-	if err := serializer.Map(r.Context(), permissionSet, &premissionSetResponse); err != nil {
-		log.Info(r.Context(), err)
-	}
-
 	var out domain.GetPermissionTemplatesResponse
-	out.Permissions = append(out.Permissions, premissionSetResponse.Dashboard)
-	out.Permissions = append(out.Permissions, premissionSetResponse.Stack)
-	out.Permissions = append(out.Permissions, premissionSetResponse.SecurityPolicy)
-	out.Permissions = append(out.Permissions, premissionSetResponse.ProjectManagement)
-	out.Permissions = append(out.Permissions, premissionSetResponse.Notification)
-	out.Permissions = append(out.Permissions, premissionSetResponse.Configuration)
+	out.Permissions = new(domain.PermissionTemplateResponse)
+
+	out.Permissions.Dashboard = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Dashboard)
+	out.Permissions.Stack = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Stack)
+	out.Permissions.Policy = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Policy)
+	out.Permissions.ProjectManagement = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.ProjectManagement)
+	out.Permissions.Notification = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Notification)
+	out.Permissions.Configuration = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Configuration)
 
 	ResponseJSON(w, r, http.StatusOK, out)
+}
+
+func convertModelToPermissionTemplateResponse(ctx context.Context, permission *model.Permission) *domain.TemplateResponse {
+	var permissionResponse domain.TemplateResponse
+
+	permissionResponse.Key = permission.Key
+	permissionResponse.Name = permission.Name
+	if permission.IsAllowed != nil {
+		permissionResponse.IsAllowed = permission.IsAllowed
+	}
+
+	for _, child := range permission.Children {
+		permissionResponse.Children = append(permissionResponse.Children, convertModelToPermissionTemplateResponse(ctx, child))
+	}
+
+	return &permissionResponse
+}
+
+// GetPermissionsByAccountId godoc
+//
+//	@Tags			Permission
+//	@Summary		Get Permissions By Account ID
+//	@Description	Get Permissions By Account ID
+//	@Accept			json
+//	@Produce		json
+//	@Success		200	{object}	domain.GetUsersPermissionsResponse
+//	@Router			/organizations/{organizationId}/users/{accountId}/permissions [get]
+//	@Security		JWT
+func (h PermissionHandler) GetPermissionsByAccountId(w http.ResponseWriter, r *http.Request) {
+	var organizationId, accountId string
+
+	vars := mux.Vars(r)
+	if v, ok := vars["accountId"]; !ok {
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
+		return
+	} else {
+		accountId = v
+	}
+	if v, ok := vars["organizationId"]; !ok {
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
+		return
+	} else {
+		organizationId = v
+	}
+
+	user, err := h.userUsecase.GetByAccountId(r.Context(), accountId, organizationId)
+	if err != nil {
+		ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
+		return
+	}
+
+	var roles []*model.Role
+	roles = append(roles, &user.Role)
+
+	var permissionSets []*model.PermissionSet
+	for _, role := range roles {
+		permissionSet, err := h.permissionUsecase.GetPermissionSetByRoleId(r.Context(), role.ID)
+		if err != nil {
+			ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
+			return
+		}
+		permissionSets = append(permissionSets, permissionSet)
+	}
+
+	mergedPermissionSet := h.permissionUsecase.MergePermissionWithOrOperator(r.Context(), permissionSets...)
+
+	var permissions domain.MergedPermissionSetResponse
+	permissions.Dashboard = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Dashboard)
+	permissions.Stack = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Stack)
+	permissions.Policy = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Policy)
+	permissions.ProjectManagement = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.ProjectManagement)
+	permissions.Notification = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Notification)
+	permissions.Configuration = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Configuration)
+
+	var out domain.GetUsersPermissionsResponse
+	out.Permissions = &permissions
+	ResponseJSON(w, r, http.StatusOK, out)
+
+}
+
+func convertModelToMergedPermissionSetResponse(ctx context.Context, permission *model.Permission) *domain.MergePermissionResponse {
+	var permissionResponse domain.MergePermissionResponse
+
+	permissionResponse.Key = permission.Key
+	if permission.IsAllowed != nil {
+		permissionResponse.IsAllowed = permission.IsAllowed
+	}
+
+	for _, child := range permission.Children {
+		permissionResponse.Children = append(permissionResponse.Children, convertModelToMergedPermissionSetResponse(ctx, child))
+	}
+
+	return &permissionResponse
 }
 
 // GetPermissionsByRoleId godoc
@@ -85,20 +176,48 @@ func (h PermissionHandler) GetPermissionsByRoleId(w http.ResponseWriter, r *http
 		return
 	}
 
-	var premissionSetResponse domain.PermissionSetResponse
-	if err := serializer.Map(r.Context(), permissionSet, &premissionSetResponse); err != nil {
-		log.Info(r.Context(), err)
-	}
+	var permissionSetResponse domain.PermissionSetResponse
+	permissionSetResponse.Dashboard = convertModelToPermissionResponse(r.Context(), permissionSet.Dashboard)
+	permissionSetResponse.Stack = convertModelToPermissionResponse(r.Context(), permissionSet.Stack)
+	permissionSetResponse.Policy = convertModelToPermissionResponse(r.Context(), permissionSet.Policy)
+	permissionSetResponse.ProjectManagement = convertModelToPermissionResponse(r.Context(), permissionSet.ProjectManagement)
+	permissionSetResponse.Notification = convertModelToPermissionResponse(r.Context(), permissionSet.Notification)
+	permissionSetResponse.Configuration = convertModelToPermissionResponse(r.Context(), permissionSet.Configuration)
 
 	var out domain.GetPermissionsByRoleIdResponse
-	out.Permissions = append(out.Permissions, premissionSetResponse.Dashboard)
-	out.Permissions = append(out.Permissions, premissionSetResponse.Stack)
-	out.Permissions = append(out.Permissions, premissionSetResponse.SecurityPolicy)
-	out.Permissions = append(out.Permissions, premissionSetResponse.ProjectManagement)
-	out.Permissions = append(out.Permissions, premissionSetResponse.Notification)
-	out.Permissions = append(out.Permissions, premissionSetResponse.Configuration)
+	out.Permissions = &permissionSetResponse
 
 	ResponseJSON(w, r, http.StatusOK, out)
+}
+
+func convertModelToPermissionResponse(ctx context.Context, permission *model.Permission) *domain.PermissionResponse {
+	var permissionResponse domain.PermissionResponse
+
+	permissionResponse.ID = permission.ID
+	permissionResponse.Key = permission.Key
+	permissionResponse.Name = permission.Name
+	if permission.IsAllowed != nil {
+		permissionResponse.IsAllowed = permission.IsAllowed
+	}
+
+	for _, endpoint := range permission.Endpoints {
+		permissionResponse.Endpoints = append(permissionResponse.Endpoints, convertModelToEndpointResponse(ctx, endpoint))
+	}
+
+	for _, child := range permission.Children {
+		permissionResponse.Children = append(permissionResponse.Children, convertModelToPermissionResponse(ctx, child))
+	}
+
+	return &permissionResponse
+}
+
+func convertModelToEndpointResponse(ctx context.Context, endpoint *model.Endpoint) *domain.EndpointResponse {
+	var endpointResponse domain.EndpointResponse
+
+	endpointResponse.Name = endpoint.Name
+	endpointResponse.Group = endpoint.Group
+
+	return &endpointResponse
 }
 
 // UpdatePermissionsByRoleId godoc
@@ -124,9 +243,8 @@ func (h PermissionHandler) UpdatePermissionsByRoleId(w http.ResponseWriter, r *h
 
 	for _, permissionResponse := range input.Permissions {
 		var permission model.Permission
-		if err := serializer.Map(r.Context(), permissionResponse, &permission); err != nil {
-			log.Info(r.Context(), err)
-		}
+		permission.ID = permissionResponse.ID
+		permission.IsAllowed = permissionResponse.IsAllowed
 
 		if err := h.permissionUsecase.UpdatePermission(r.Context(), &permission); err != nil {
 			ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))

--- a/internal/delivery/http/permission.go
+++ b/internal/delivery/http/permission.go
@@ -15,6 +15,7 @@ type IPermissionHandler interface {
 	GetPermissionTemplates(w http.ResponseWriter, r *http.Request)
 	GetPermissionsByRoleId(w http.ResponseWriter, r *http.Request)
 	UpdatePermissionsByRoleId(w http.ResponseWriter, r *http.Request)
+	GetPermissionsByAccountId(w http.ResponseWriter, r *http.Request)
 }
 
 type PermissionHandler struct {
@@ -22,7 +23,7 @@ type PermissionHandler struct {
 	userUsecase       usecase.IUserUsecase
 }
 
-func NewPermissionHandler(usecase usecase.Usecase) *PermissionHandler {
+func NewPermissionHandler(usecase usecase.Usecase) IPermissionHandler {
 	return &PermissionHandler{
 		permissionUsecase: usecase.Permission,
 		userUsecase:       usecase.User,

--- a/internal/model/permission.go
+++ b/internal/model/permission.go
@@ -11,9 +11,9 @@ type PermissionKind string
 
 const (
 	DashBoardPermission         PermissionKind = "대시보드"
-	StackPermission             PermissionKind = "스택 관리"
-	SecurityPolicyPermission    PermissionKind = "보안/정책 관리"
-	ProjectManagementPermission PermissionKind = "프로젝트 관리"
+	StackPermission             PermissionKind = "스택"
+	SecurityPolicyPermission    PermissionKind = "정책"
+	ProjectManagementPermission PermissionKind = "프로젝트"
 	NotificationPermission      PermissionKind = "알림"
 	ConfigurationPermission     PermissionKind = "설정"
 )
@@ -42,6 +42,8 @@ type PermissionSet struct {
 	ProjectManagement *Permission `gorm:"-:all" json:"project_management,omitempty"`
 	Notification      *Permission `gorm:"-:all" json:"notification,omitempty"`
 	Configuration     *Permission `gorm:"-:all" json:"configuration,omitempty"`
+	Common            *Permission `gorm:"-:all" json:"common,omitempty"`
+	Admin             *Permission `gorm:"-:all" json:"admin,omitempty"`
 }
 
 func NewDefaultPermissionSet() *PermissionSet {
@@ -52,6 +54,20 @@ func NewDefaultPermissionSet() *PermissionSet {
 		ProjectManagement: newProjectManagement(),
 		Notification:      newNotification(),
 		Configuration:     newConfiguration(),
+		Common:            newCommon(),
+	}
+}
+
+func NewAdminPermissionSet() *PermissionSet {
+	return &PermissionSet{
+		Admin:             newAdmin(),
+		Dashboard:         newDashboard(),
+		Stack:             newStack(),
+		SecurityPolicy:    newSecurityPolicy(),
+		ProjectManagement: newProjectManagement(),
+		Notification:      newNotification(),
+		Configuration:     newConfiguration(),
+		Common:            newCommon(),
 	}
 }
 
@@ -101,30 +117,9 @@ func newDashboard() *Permission {
 							api.GetResourcesDashboard,
 						),
 					},
-				},
-			},
-			{
-				ID:   uuid.New(),
-				Name: "대시보드 설정",
-				Children: []*Permission{
-					{
-						ID:        uuid.New(),
-						Name:      "조회",
-						IsAllowed: helper.BoolP(false),
-					},
-					{
-						ID:        uuid.New(),
-						Name:      "생성",
-						IsAllowed: helper.BoolP(false),
-					},
 					{
 						ID:        uuid.New(),
 						Name:      "수정",
-						IsAllowed: helper.BoolP(false),
-					},
-					{
-						ID:        uuid.New(),
-						Name:      "삭제",
 						IsAllowed: helper.BoolP(false),
 					},
 				},
@@ -141,44 +136,79 @@ func newStack() *Permission {
 		Name: string(StackPermission),
 		Children: []*Permission{
 			{
-				ID:        uuid.New(),
-				Name:      "조회",
-				IsAllowed: helper.BoolP(false),
-				Endpoints: endpointObjects(
-					api.GetStacks,
-					api.GetStack,
-					api.CheckStackName,
-					api.GetStackStatus,
-					api.GetStackKubeConfig,
+				ID:   uuid.New(),
+				Name: "스택",
+				Children: []*Permission{
+					{
+						ID:        uuid.New(),
+						Name:      "조회",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.GetStacks,
+							api.GetStack,
+							api.CheckStackName,
+							api.GetStackStatus,
+							api.GetStackKubeConfig,
 
-					api.SetFavoriteStack,
-					api.DeleteFavoriteStack,
-				),
-			},
-			{
-				ID:        uuid.New(),
-				Name:      "생성",
-				IsAllowed: helper.BoolP(false),
-				Endpoints: endpointObjects(
-					api.CreateStack,
-					api.InstallStack,
-				),
-			},
-			{
-				ID:        uuid.New(),
-				Name:      "수정",
-				IsAllowed: helper.BoolP(false),
-				Endpoints: endpointObjects(
-					api.UpdateStack,
-				),
-			},
-			{
-				ID:        uuid.New(),
-				Name:      "삭제",
-				IsAllowed: helper.BoolP(false),
-				Endpoints: endpointObjects(
-					api.DeleteStack,
-				),
+							api.SetFavoriteStack,
+							api.DeleteFavoriteStack,
+
+							// Cluster
+							api.GetCluster,
+							api.GetClusters,
+							api.GetClusterSiteValues,
+							api.GetBootstrapKubeconfig,
+							api.GetNodes,
+
+							// AppGroup
+							api.GetAppgroups,
+							api.GetAppgroup,
+							api.GetApplications,
+						),
+					},
+					{
+						ID:        uuid.New(),
+						Name:      "생성",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.CreateStack,
+							api.InstallStack,
+							api.CreateAppgroup,
+
+							// Cluster
+							api.CreateCluster,
+							api.ImportCluster,
+							api.InstallCluster,
+							api.CreateBootstrapKubeconfig,
+
+							// AppGroup
+							api.CreateAppgroup,
+							api.CreateApplication,
+						),
+					},
+					{
+						ID:        uuid.New(),
+						Name:      "수정",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.UpdateStack,
+						),
+					},
+					{
+						ID:        uuid.New(),
+						Name:      "삭제",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.DeleteStack,
+
+							// Cluster
+							api.DeleteCluster,
+
+							// AppGroup
+							api.DeleteAppgroup,
+						),
+					},
+				},
 			},
 		},
 	}
@@ -193,27 +223,107 @@ func newSecurityPolicy() *Permission {
 		Children: []*Permission{
 			{
 				ID:   uuid.New(),
-				Name: "보안/정책",
+				Name: "정책",
 				Children: []*Permission{
 					{
 						ID:        uuid.New(),
 						Name:      "조회",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							// PolicyTemplate
+							api.ListPolicyTemplate,
+							api.GetPolicyTemplate,
+							api.GetPolicyTemplateDeploy,
+							api.ListPolicyTemplateStatistics,
+							api.ListPolicyTemplateVersions,
+							api.GetPolicyTemplateVersion,
+							api.ExistsPolicyTemplateName,
+							api.ExistsPolicyTemplateKind,
+
+							// ClusterPolicyStatus
+							api.ListClusterPolicyStatus,
+							api.GetClusterPolicyTemplateStatus,
+
+							// Policy
+							api.GetMandatoryPolicies,
+							api.ListPolicy,
+							api.GetPolicy,
+							api.ExistsPolicyName,
+
+							// OrganizationPolicyTemplate
+							api.ListOrganizationPolicyTemplate,
+							api.GetOrganizationPolicyTemplate,
+							api.GetOrganizationPolicyTemplateDeploy,
+							api.ListOrganizationPolicyTemplateStatistics,
+							api.ListOrganizationPolicyTemplateVersions,
+							api.GetOrganizationPolicyTemplateVersion,
+							api.ExistsOrganizationPolicyTemplateKind,
+							api.ExistsOrganizationPolicyTemplateName,
+
+							// PolicyTemplateExample
+							api.ListPolicyTemplateExample,
+							api.GetPolicyTemplateExample,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "생성",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							// PolicyTemplate
+							api.CreatePolicyTemplate,
+							api.CreatePolicyTemplateVersion,
+
+							// Policy
+							api.SetMandatoryPolicies,
+							api.CreatePolicy,
+
+							// OrganizationPolicyTemplate
+							api.CreateOrganizationPolicyTemplate,
+							api.CreateOrganizationPolicyTemplateVersion,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "수정",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							// PolicyTemplate
+							api.UpdatePolicyTemplate,
+
+							// ClusterPolicyStatus
+							api.UpdateClusterPolicyTemplateStatus,
+
+							// Policy
+							api.UpdatePolicy,
+							api.UpdatePolicyTargetClusters,
+
+							// OrganizationPolicyTemplate
+							api.UpdateOrganizationPolicyTemplate,
+
+							// PolicyTemplateExample
+							api.UpdatePolicyTemplateExample,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "삭제",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							// PolicyTemplate
+							api.DeletePolicyTemplate,
+							api.DeletePolicyTemplateVersion,
+
+							// Policy
+							api.DeletePolicy,
+
+							// OrganizationPolicyTemplate
+							api.DeleteOrganizationPolicyTemplate,
+							api.DeleteOrganizationPolicyTemplateVersion,
+
+							// PolicyTemplateExample
+							api.DeletePolicyTemplateExample,
+						),
 					},
 				},
 			},
@@ -221,6 +331,65 @@ func newSecurityPolicy() *Permission {
 	}
 
 	return security_policy
+}
+
+func newNotification() *Permission {
+	notification := &Permission{
+		ID:   uuid.New(),
+		Name: string(NotificationPermission),
+		Children: []*Permission{
+			{
+				ID:   uuid.New(),
+				Name: "시스템 알림",
+				Children: []*Permission{
+					{
+						ID:        uuid.New(),
+						Name:      "조회",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.GetSystemNotification,
+							api.GetSystemNotifications,
+						),
+					},
+					{
+						ID:        uuid.New(),
+						Name:      "수정",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.UpdateSystemNotification,
+							api.CreateSystemNotificationAction,
+						),
+					},
+					{
+						ID:        uuid.New(),
+						Name:      "다운로드",
+						IsAllowed: helper.BoolP(false),
+						Children:  []*Permission{},
+					},
+				},
+			},
+			{
+				ID:   uuid.New(),
+				Name: "정책 알림",
+				Children: []*Permission{
+					{
+						ID:        uuid.New(),
+						Name:      "조회",
+						IsAllowed: helper.BoolP(false),
+						Children:  []*Permission{},
+					},
+					{
+						ID:        uuid.New(),
+						Name:      "다운로드",
+						IsAllowed: helper.BoolP(false),
+						Children:  []*Permission{},
+					},
+				},
+			},
+		},
+	}
+
+	return notification
 }
 
 func newProjectManagement() *Permission {
@@ -239,6 +408,7 @@ func newProjectManagement() *Permission {
 						Endpoints: endpointObjects(
 							api.GetProjects,
 							api.GetProject,
+							api.GetProjectKubeconfig,
 						),
 					},
 					{
@@ -247,79 +417,6 @@ func newProjectManagement() *Permission {
 						IsAllowed: helper.BoolP(false),
 						Endpoints: endpointObjects(
 							api.CreateProject,
-						),
-					},
-				},
-			},
-			{
-				ID:   uuid.New(),
-				Name: "앱 서빙",
-				Children: []*Permission{
-					{
-						ID:        uuid.New(),
-						Name:      "조회",
-						IsAllowed: helper.BoolP(false),
-						Endpoints: endpointObjects(
-							api.GetAppServeApps,
-							api.GetAppServeApp,
-							api.GetNumOfAppsOnStack,
-							api.GetAppServeAppLatestTask,
-							api.IsAppServeAppExist,
-							api.IsAppServeAppNameExist,
-						),
-					},
-					{
-						ID:        uuid.New(),
-						Name:      "빌드",
-						IsAllowed: helper.BoolP(false),
-						Endpoints: endpointObjects(
-							api.CreateAppServeApp,
-							api.IsAppServeAppExist,
-							api.IsAppServeAppNameExist,
-							api.UpdateAppServeApp,
-							api.UpdateAppServeAppEndpoint,
-							api.UpdateAppServeAppStatus,
-							api.RollbackAppServeApp,
-						),
-					},
-					{
-						ID:        uuid.New(),
-						Name:      "배포",
-						IsAllowed: helper.BoolP(false),
-						Endpoints: endpointObjects(
-							api.CreateAppServeApp,
-							api.IsAppServeAppExist,
-							api.IsAppServeAppNameExist,
-							api.UpdateAppServeApp,
-							api.UpdateAppServeAppEndpoint,
-							api.UpdateAppServeAppStatus,
-							api.RollbackAppServeApp,
-						),
-					},
-					{
-						ID:        uuid.New(),
-						Name:      "삭제",
-						IsAllowed: helper.BoolP(false),
-						Endpoints: endpointObjects(
-							api.DeleteAppServeApp,
-						),
-					},
-				},
-			},
-			{
-				ID:   uuid.New(),
-				Name: "설정-일반",
-				Children: []*Permission{
-					{
-						ID:        uuid.New(),
-						Name:      "조회",
-						IsAllowed: helper.BoolP(false),
-						Endpoints: endpointObjects(
-							api.GetProjects,
-							api.GetProject,
-
-							api.GetProjectRoles,
-							api.GetProjectRole,
 						),
 					},
 					{
@@ -342,7 +439,33 @@ func newProjectManagement() *Permission {
 			},
 			{
 				ID:   uuid.New(),
-				Name: "설정-멤버",
+				Name: "일반 설정",
+				Children: []*Permission{
+					{
+						ID:        uuid.New(),
+						Name:      "조회",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.GetProjects,
+							api.GetProject,
+
+							api.GetProjectRoles,
+							api.GetProjectRole,
+						),
+					},
+					{
+						ID:        uuid.New(),
+						Name:      "수정",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.UpdateProject,
+						),
+					},
+				},
+			},
+			{
+				ID:   uuid.New(),
+				Name: "구성원 설정",
 				Children: []*Permission{
 					{
 						ID:        uuid.New(),
@@ -383,7 +506,7 @@ func newProjectManagement() *Permission {
 			},
 			{
 				ID:   uuid.New(),
-				Name: "설정-네임스페이스",
+				Name: "네임스페이스",
 				Children: []*Permission{
 					{
 						ID:        uuid.New(),
@@ -392,6 +515,7 @@ func newProjectManagement() *Permission {
 						Endpoints: endpointObjects(
 							api.GetProjectNamespaces,
 							api.GetProjectNamespace,
+							api.GetProjectNamespaceK8sResources,
 						),
 					},
 					{
@@ -406,7 +530,9 @@ func newProjectManagement() *Permission {
 						ID:        uuid.New(),
 						Name:      "수정",
 						IsAllowed: helper.BoolP(false),
-						Endpoints: endpointObjects(),
+						Endpoints: endpointObjects(
+							api.UpdateProjectNamespace,
+						),
 					},
 					{
 						ID:        uuid.New(),
@@ -418,43 +544,67 @@ func newProjectManagement() *Permission {
 					},
 				},
 			},
+			{
+				ID:   uuid.New(),
+				Name: "앱 서빙",
+				Children: []*Permission{
+					{
+						ID:        uuid.New(),
+						Name:      "조회",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.GetAppServeApps,
+							api.GetAppServeApp,
+							api.GetNumOfAppsOnStack,
+							api.GetAppServeAppLatestTask,
+							api.IsAppServeAppExist,
+							api.IsAppServeAppNameExist,
+							api.GetAppServeAppTaskDetail,
+							api.GetAppServeAppTasksByAppId,
+						),
+					},
+					{
+						ID:        uuid.New(),
+						Name:      "생성",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.CreateAppServeApp,
+							api.IsAppServeAppExist,
+							api.IsAppServeAppNameExist,
+							api.UpdateAppServeApp,
+							api.UpdateAppServeAppEndpoint,
+							api.UpdateAppServeAppStatus,
+							api.RollbackAppServeApp,
+						),
+					},
+					{
+						ID:        uuid.New(),
+						Name:      "수정",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.CreateAppServeApp,
+							api.IsAppServeAppExist,
+							api.IsAppServeAppNameExist,
+							api.UpdateAppServeApp,
+							api.UpdateAppServeAppEndpoint,
+							api.UpdateAppServeAppStatus,
+							api.RollbackAppServeApp,
+						),
+					},
+					{
+						ID:        uuid.New(),
+						Name:      "삭제",
+						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.DeleteAppServeApp,
+						),
+					},
+				},
+			},
 		},
 	}
 
 	return projectManagement
-}
-
-func newNotification() *Permission {
-	notification := &Permission{
-		ID:   uuid.New(),
-		Name: string(NotificationPermission),
-		Children: []*Permission{
-			{
-				ID:   uuid.New(),
-				Name: "시스템 경고",
-				Children: []*Permission{
-					{
-						ID:        uuid.New(),
-						Name:      "조회",
-						IsAllowed: helper.BoolP(false),
-					},
-				},
-			},
-			{
-				ID:   uuid.New(),
-				Name: "보안/정책 감사로그",
-				Children: []*Permission{
-					{
-						ID:        uuid.New(),
-						Name:      "조회",
-						IsAllowed: helper.BoolP(false),
-					},
-				},
-			},
-		},
-	}
-
-	return notification
 }
 
 func newConfiguration() *Permission {
@@ -486,57 +636,53 @@ func newConfiguration() *Permission {
 						ID:        uuid.New(),
 						Name:      "조회",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.GetCloudAccounts,
+							api.GetCloudAccount,
+							api.CheckCloudAccountName,
+							api.CheckAwsAccountId,
+							api.GetResourceQuota,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "생성",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.CreateCloudAccount,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "수정",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.UpdateCloudAccount,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "삭제",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.DeleteCloudAccount,
+							api.DeleteForceCloudAccount,
+						),
 					},
 				},
 			},
 			{
 				ID:   uuid.New(),
-				Name: "스택 템플릿",
+				Name: "프로젝트",
 				Children: []*Permission{
 					{
 						ID:        uuid.New(),
 						Name:      "조회",
 						IsAllowed: helper.BoolP(false),
 					},
-				},
-			},
-			{
-				ID:   uuid.New(),
-				Name: "프로젝트 관리",
-				Children: []*Permission{
-					{
-						ID:        uuid.New(),
-						Name:      "조회",
-						IsAllowed: helper.BoolP(false),
-					},
 					{
 						ID:        uuid.New(),
 						Name:      "생성",
-						IsAllowed: helper.BoolP(false),
-					},
-					{
-						ID:        uuid.New(),
-						Name:      "수정",
-						IsAllowed: helper.BoolP(false),
-					},
-					{
-						ID:        uuid.New(),
-						Name:      "삭제",
 						IsAllowed: helper.BoolP(false),
 					},
 				},
@@ -549,73 +695,120 @@ func newConfiguration() *Permission {
 						ID:        uuid.New(),
 						Name:      "조회",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.ListUser,
+							api.GetUser,
+							api.CheckId,
+							api.CheckEmail,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "생성",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.CreateUser,
+							api.CheckId,
+							api.CheckEmail,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "수정",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.UpdateUser,
+							api.ResetPassword,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "삭제",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.DeleteUser,
+						),
 					},
 				},
 			},
 			{
 				ID:   uuid.New(),
-				Name: "사용자 권한 관리",
+				Name: "역할 및 권한",
 				Children: []*Permission{
 					{
 						ID:        uuid.New(),
 						Name:      "조회",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.ListTksRoles,
+							api.GetTksRole,
+							api.GetPermissionsByRoleId,
+							api.GetPermissionTemplates,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "생성",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.CreateTksRole,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "수정",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.UpdateTksRole,
+							api.UpdatePermissionsByRoleId,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "삭제",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.DeleteTksRole,
+						),
 					},
 				},
 			},
 			{
 				ID:   uuid.New(),
-				Name: "알림 설정",
+				Name: "시스템 알림",
 				Children: []*Permission{
 					{
 						ID:        uuid.New(),
 						Name:      "조회",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.GetSystemNotificationRules,
+							api.GetSystemNotificationRule,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "생성",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.CreateSystemNotificationRule,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "수정",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.UpdateSystemNotificationRule,
+						),
 					},
 					{
 						ID:        uuid.New(),
 						Name:      "삭제",
 						IsAllowed: helper.BoolP(false),
+						Endpoints: endpointObjects(
+							api.DeleteSystemNotificationRule,
+						),
 					},
 				},
 			},
@@ -623,6 +816,110 @@ func newConfiguration() *Permission {
 	}
 
 	return configuration
+}
+
+func newCommon() *Permission {
+	common := &Permission{
+		ID:        uuid.New(),
+		Name:      "공통",
+		IsAllowed: helper.BoolP(true),
+		Endpoints: endpointObjects(
+			// Auth
+			api.Login,
+			api.Logout,
+			api.RefreshToken,
+			api.FindId,
+			api.FindPassword,
+			api.VerifyIdentityForLostId,
+			api.VerifyIdentityForLostPassword,
+			api.VerifyToken,
+
+			// Stack
+			api.SetFavoriteStack,
+			api.DeleteFavoriteStack,
+
+			// Project
+			api.SetFavoriteProject,
+			api.SetFavoriteProjectNamespace,
+			api.UnSetFavoriteProject,
+			api.UnSetFavoriteProjectNamespace,
+
+			// MyProfile
+			api.GetMyProfile,
+			api.UpdateMyProfile,
+			api.UpdateMyPassword,
+			api.RenewPasswordExpiredDate,
+			api.DeleteMyProfile,
+
+			// StackTemplate
+			api.GetOrganizationStackTemplates,
+			api.GetOrganizationStackTemplate,
+
+			// Utiliy
+			api.CompileRego,
+		),
+	}
+
+	return common
+
+}
+
+func newAdmin() *Permission {
+	admin := &Permission{
+		ID:        uuid.New(),
+		Name:      "관리자",
+		IsAllowed: helper.BoolP(true),
+		Endpoints: endpointObjects(
+			// Organization
+			api.Admin_CreateOrganization,
+			api.Admin_DeleteOrganization,
+			api.UpdateOrganization,
+			api.GetOrganization,
+			api.GetOrganizations,
+			api.UpdatePrimaryCluster,
+			api.CheckOrganizationName,
+
+			// User
+			api.ResetPassword,
+			api.CheckId,
+			api.CheckEmail,
+
+			// StackTemplate
+			api.Admin_GetStackTemplates,
+			api.Admin_GetStackTemplate,
+			api.Admin_GetStackTemplateServices,
+			api.Admin_CreateStackTemplate,
+			api.Admin_UpdateStackTemplate,
+			api.Admin_DeleteStackTemplate,
+			api.Admin_UpdateStackTemplateOrganizations,
+			api.Admin_CheckStackTemplateName,
+
+			// Admin
+			api.Admin_GetUser,
+			api.Admin_ListUser,
+			api.Admin_CreateUser,
+			api.Admin_UpdateUser,
+			api.Admin_DeleteUser,
+			api.Admin_GetSystemNotificationTemplate,
+			api.Admin_CreateSystemNotificationTemplate,
+			api.Admin_ListUser,
+			api.Admin_GetTksRole,
+			api.Admin_GetProjects,
+			api.Admin_UpdateSystemNotificationTemplate,
+			api.Admin_ListTksRoles,
+			api.Admin_GetSystemNotificationTemplates,
+
+			// Audit
+			api.GetAudits,
+			api.GetAudit,
+			api.DeleteAudit,
+
+			api.CreateSystemNotification,
+			api.DeleteSystemNotification,
+		),
+	}
+
+	return admin
 }
 
 func (p *PermissionSet) SetAllowedPermissionSet() {

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -291,6 +291,7 @@ func SetupRouter(db *gorm.DB, argoClient argowf.ArgoClient, kc keycloak.IKeycloa
 	r.Handle(API_PREFIX+API_VERSION+"/permissions/templates", customMiddleware.Handle(internalApi.GetPermissionTemplates, http.HandlerFunc(permissionHandler.GetPermissionTemplates))).Methods(http.MethodGet)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleId}/permissions", customMiddleware.Handle(internalApi.GetPermissionsByRoleId, http.HandlerFunc(permissionHandler.GetPermissionsByRoleId))).Methods(http.MethodGet)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleId}/permissions", customMiddleware.Handle(internalApi.UpdatePermissionsByRoleId, http.HandlerFunc(permissionHandler.UpdatePermissionsByRoleId))).Methods(http.MethodPut)
+	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/users/{accountId}/permissions", customMiddleware.Handle(internalApi.GetPermissionsByAccountId, http.HandlerFunc(permissionHandler.GetPermissionsByAccountId))).Methods(http.MethodGet)
 
 	policyTemplateHandler := delivery.NewPolicyTemplateHandler(usecaseFactory)
 	r.Handle(API_PREFIX+API_VERSION+ADMINAPI_PREFIX+"/policy-templates", customMiddleware.Handle(internalApi.ListPolicyTemplate, http.HandlerFunc(policyTemplateHandler.ListPolicyTemplate))).Methods(http.MethodGet)

--- a/internal/usecase/organization.go
+++ b/internal/usecase/organization.go
@@ -35,7 +35,6 @@ type OrganizationUsecase struct {
 	roleRepo                       repository.IRoleRepository
 	clusterRepo                    repository.IClusterRepository
 	stackTemplateRepo              repository.IStackTemplateRepository
-	policyTemplateRepo             repository.IPolicyTemplateRepository
 	systemNotificationTemplateRepo repository.ISystemNotificationTemplateRepository
 	argo                           argowf.ArgoClient
 	kc                             keycloak.IKeycloak

--- a/pkg/domain/endpoint.go
+++ b/pkg/domain/endpoint.go
@@ -1,10 +1,6 @@
 package domain
 
-import "time"
-
 type EndpointResponse struct {
-	Name      string    `json:"name"`
-	Group     string    `json:"group"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	Name  string `json:"name"`
+	Group string `json:"group"`
 }

--- a/pkg/domain/permission.go
+++ b/pkg/domain/permission.go
@@ -8,11 +8,7 @@ type PermissionResponse struct {
 	ID        uuid.UUID             `json:"ID"`
 	Name      string                `json:"name"`
 	IsAllowed *bool                 `json:"is_allowed,omitempty"`
-	RoleID    *string               `json:"role_id,omitempty"`
-	Role      *RoleResponse         `json:"role,omitempty"`
 	Endpoints []*EndpointResponse   `json:"endpoints,omitempty"`
-	ParentID  *uuid.UUID            `json:"parent_id,omitempty"`
-	Parent    *PermissionResponse   `json:"parent,omitempty"`
 	Children  []*PermissionResponse `json:"children,omitempty"`
 }
 

--- a/pkg/domain/permission.go
+++ b/pkg/domain/permission.go
@@ -4,31 +4,67 @@ import (
 	"github.com/google/uuid"
 )
 
-type PermissionResponse struct {
-	ID        uuid.UUID             `json:"ID"`
-	Name      string                `json:"name"`
-	IsAllowed *bool                 `json:"is_allowed,omitempty"`
-	Endpoints []*EndpointResponse   `json:"endpoints,omitempty"`
-	Children  []*PermissionResponse `json:"children,omitempty"`
+type GetPermissionTemplatesResponse struct {
+	Permissions *PermissionTemplateResponse `json:"permissions"`
+}
+
+type PermissionTemplateResponse struct {
+	Dashboard         *TemplateResponse `json:"dashboard,omitempty"`
+	Stack             *TemplateResponse `json:"stack,omitempty"`
+	Policy            *TemplateResponse `json:"policy,omitempty"`
+	ProjectManagement *TemplateResponse `json:"project_management,omitempty"`
+	Notification      *TemplateResponse `json:"notification,omitempty"`
+	Configuration     *TemplateResponse `json:"configuration,omitempty"`
+}
+
+type TemplateResponse struct {
+	Name      string              `json:"name"`
+	Key       string              `json:"key"`
+	IsAllowed *bool               `json:"is_allowed,omitempty"`
+	Children  []*TemplateResponse `json:"children,omitempty"`
+}
+
+type GetPermissionsByRoleIdResponse struct {
+	Permissions *PermissionSetResponse `json:"permissions"`
 }
 
 type PermissionSetResponse struct {
 	Dashboard         *PermissionResponse `json:"dashboard,omitempty"`
 	Stack             *PermissionResponse `json:"stack,omitempty"`
-	SecurityPolicy    *PermissionResponse `json:"security_policy,omitempty"`
+	Policy            *PermissionResponse `json:"policy,omitempty"`
 	ProjectManagement *PermissionResponse `json:"project_management,omitempty"`
 	Notification      *PermissionResponse `json:"notification,omitempty"`
 	Configuration     *PermissionResponse `json:"configuration,omitempty"`
 }
 
-type GetPermissionTemplatesResponse struct {
-	Permissions []*PermissionResponse `json:"permissions"`
-}
-
-type GetPermissionsByRoleIdResponse struct {
-	Permissions []*PermissionResponse `json:"permissions"`
+type PermissionResponse struct {
+	ID        uuid.UUID             `json:"ID"`
+	Name      string                `json:"name"`
+	Key       string                `json:"key"`
+	IsAllowed *bool                 `json:"is_allowed,omitempty"`
+	Endpoints []*EndpointResponse   `json:"endpoints,omitempty"`
+	Children  []*PermissionResponse `json:"children,omitempty"`
 }
 
 type UpdatePermissionsByRoleIdRequest struct {
 	Permissions []*PermissionResponse `json:"permissions"`
+}
+
+type GetUsersPermissionsResponse struct {
+	Permissions *MergedPermissionSetResponse `json:"permissions"`
+}
+
+type MergedPermissionSetResponse struct {
+	Dashboard         *MergePermissionResponse `json:"dashboard,omitempty"`
+	Stack             *MergePermissionResponse `json:"stack,omitempty"`
+	Policy            *MergePermissionResponse `json:"policy,omitempty"`
+	ProjectManagement *MergePermissionResponse `json:"project_management,omitempty"`
+	Notification      *MergePermissionResponse `json:"notification,omitempty"`
+	Configuration     *MergePermissionResponse `json:"configuration,omitempty"`
+}
+
+type MergePermissionResponse struct {
+	Key       string                     `json:"key"`
+	IsAllowed *bool                      `json:"is_allowed,omitempty"`
+	Children  []*MergePermissionResponse `json:"children,omitempty"`
 }


### PR DESCRIPTION
Frontend:
- 현재 개발 내용은 기존 조직에 대해서는 동작하지 않으니, PR 이후 새로 조직 생성하여 이용가능합니다.
- 각 Permission의 Key에 대한 정보는 slack에 업로드합니다.

Backend:
- Permission 관련 serializer.Map()에 오동작으로 임시로 model->domain 변환에 대한 convert() 함수 만들었습니다.
- 이후, Map() 함수 개선 이후 convert()함수 사용은 모두 교체 예정입니다.
- [Lint] 'policyTemplateRepo' 에러 수정했습니다.