### PR TITLE
TKS 역할 또는 Project 역할 변경 시, 사용자가 새로운 access token을 발급 받도록 개선

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ses v1.21.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.27.0
 	github.com/deckarep/golang-set/v2 v2.6.0
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.18.0

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -61,7 +61,10 @@ func InitDB() (*gorm.DB, error) {
 
 func migrateSchema(db *gorm.DB) error {
 	// Auth
-	if err := db.AutoMigrate(&repository.CacheEmailCode{}); err != nil {
+	if err := db.AutoMigrate(&model.CacheEmailCode{}); err != nil {
+		return err
+	}
+	if err := db.AutoMigrate(&model.ExpiredTokenTime{}); err != nil {
 		return err
 	}
 	if err := db.AutoMigrate(&model.User{}); err != nil {

--- a/internal/delivery/http/auth.go
+++ b/internal/delivery/http/auth.go
@@ -310,7 +310,7 @@ func (h *AuthHandler) VerifyToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !isActive {
-		ErrorJSON(w, r, httpErrors.NewUnauthorizedError(fmt.Errorf("token is not active"), "A_UNUSABLE_TOKEN", ""))
+		ErrorJSON(w, r, httpErrors.NewUnauthorizedError(fmt.Errorf("token is not active"), "A_EXPIRED_TOKEN", ""))
 		return
 	}
 

--- a/internal/delivery/http/project.go
+++ b/internal/delivery/http/project.go
@@ -58,12 +58,14 @@ type IProjectHandler interface {
 }
 
 type ProjectHandler struct {
-	usecase usecase.IProjectUsecase
+	usecase     usecase.IProjectUsecase
+	authUsecase usecase.IAuthUsecase
 }
 
 func NewProjectHandler(u usecase.Usecase) IProjectHandler {
 	return &ProjectHandler{
-		usecase: u.Project,
+		usecase:     u.Project,
+		authUsecase: u.Auth,
 	}
 }
 
@@ -624,6 +626,13 @@ func (p ProjectHandler) AddProjectMember(w http.ResponseWriter, r *http.Request)
 				return
 			}
 		}
+
+		err = p.authUsecase.UpdateExpiredTimeOnToken(r.Context(), organizationId, pmr.ProjectUserId)
+		if err != nil {
+			log.Error(r.Context(), err)
+			ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
+			return
+		}
 	}
 
 	out := domain.CommonProjectResponse{Result: "OK"}
@@ -898,6 +907,20 @@ func (p ProjectHandler) RemoveProjectMember(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
+	pm, err := p.usecase.GetProjectMember(r.Context(), projectMemberId)
+	if err != nil {
+		log.Error(r.Context(), err)
+		ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
+		return
+	}
+
+	err = p.authUsecase.UpdateExpiredTimeOnToken(r.Context(), organizationId, pm.ProjectUserId.String())
+	if err != nil {
+		log.Error(r.Context(), err)
+		ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
+		return
+	}
+
 	if err := p.usecase.RemoveProjectMember(r.Context(), organizationId, projectMemberId); err != nil {
 		ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
 		return
@@ -956,8 +979,8 @@ func (p ProjectHandler) RemoveProjectMembers(w http.ResponseWriter, r *http.Requ
 	}
 
 	// TODO: change multi row delete
-	for _, pm := range projectMemberReq.ProjectMember {
-		if err := p.usecase.UnassignKeycloakClientRoleToMember(r.Context(), organizationId, projectId, keycloak.DefaultClientID, pm.ProjectMemberId); err != nil {
+	for _, pmId := range projectMemberReq.ProjectMember {
+		if err := p.usecase.UnassignKeycloakClientRoleToMember(r.Context(), organizationId, projectId, keycloak.DefaultClientID, pmId.ProjectMemberId); err != nil {
 			log.Error(r.Context(), err)
 			ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
 			return
@@ -965,14 +988,22 @@ func (p ProjectHandler) RemoveProjectMembers(w http.ResponseWriter, r *http.Requ
 
 		// tasks for keycloak & k8s
 		for stackId := range stackIds {
-			if err := p.usecase.UnassignKeycloakClientRoleToMember(r.Context(), organizationId, projectId, stackId+"-k8s-api", pm.ProjectMemberId); err != nil {
+			if err := p.usecase.UnassignKeycloakClientRoleToMember(r.Context(), organizationId, projectId, stackId+"-k8s-api", pmId.ProjectMemberId); err != nil {
 				log.Error(r.Context(), err)
 				ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
 				return
 			}
 		}
 
-		if err := p.usecase.RemoveProjectMember(r.Context(), organizationId, pm.ProjectMemberId); err != nil {
+		pm, err := p.usecase.GetProjectMember(r.Context(), pmId.ProjectMemberId)
+		if err != nil {
+			log.Error(r.Context(), err)
+			ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
+			return
+		}
+		err = p.authUsecase.UpdateExpiredTimeOnToken(r.Context(), organizationId, pm.ProjectUserId.String())
+
+		if err := p.usecase.RemoveProjectMember(r.Context(), organizationId, pmId.ProjectMemberId); err != nil {
 			ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
 			return
 		}
@@ -1088,6 +1119,14 @@ func (p ProjectHandler) UpdateProjectMemberRole(w http.ResponseWriter, r *http.R
 		}
 	}
 
+	// update token expired time
+	err = p.authUsecase.UpdateExpiredTimeOnToken(r.Context(), organizationId, pm.ProjectUserId.String())
+	if err != nil {
+		log.Error(r.Context(), err)
+		ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
+		return
+	}
+
 	ResponseJSON(w, r, http.StatusOK, domain.CommonProjectResponse{Result: "OK"})
 }
 
@@ -1189,6 +1228,14 @@ func (p ProjectHandler) UpdateProjectMembersRole(w http.ResponseWriter, r *http.
 				ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
 				return
 			}
+		}
+
+		// update token expired time
+		err = p.authUsecase.UpdateExpiredTimeOnToken(r.Context(), organizationId, pm.ProjectUserId.String())
+		if err != nil {
+			log.Error(r.Context(), err)
+			ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
+			return
 		}
 	}
 

--- a/internal/delivery/http/project.go
+++ b/internal/delivery/http/project.go
@@ -1002,6 +1002,11 @@ func (p ProjectHandler) RemoveProjectMembers(w http.ResponseWriter, r *http.Requ
 			return
 		}
 		err = p.authUsecase.UpdateExpiredTimeOnToken(r.Context(), organizationId, pm.ProjectUserId.String())
+		if err != nil {
+			log.Error(r.Context(), err)
+			ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
+			return
+		}
 
 		if err := p.usecase.RemoveProjectMember(r.Context(), organizationId, pmId.ProjectMemberId); err != nil {
 			ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))

--- a/internal/helper/jwt.go
+++ b/internal/helper/jwt.go
@@ -1,9 +1,10 @@
 package helper
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/spf13/viper"
 )
 
@@ -36,4 +37,19 @@ func VerifyToken(tokenString string) (*jwt.Token, error) {
 		return nil, err
 	}
 	return token, err
+}
+
+func StringToTokenWithoutVerification(tokenString string) (*jwt.Token, error) {
+	token, _, err := new(jwt.Parser).ParseUnverified(tokenString, jwt.MapClaims{})
+	if err != nil {
+		return nil, fmt.Errorf("invalid token")
+	}
+	return token, nil
+}
+func RetrieveClaims(token *jwt.Token) (map[string]interface{}, error) {
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("invalid token")
+	}
+	return claims, nil
 }

--- a/internal/keycloak/config.go
+++ b/internal/keycloak/config.go
@@ -12,7 +12,7 @@ const (
 	DefaultClientID       = "tks"
 	DefaultClientSecret   = "secret"
 	AdminCliClientID      = "admin-cli"
-	accessTokenLifespan   = 60 * 60 * 24 // 1 day
-	ssoSessionIdleTimeout = 60 * 60 * 24 // 1 day
-	ssoSessionMaxLifespan = 60 * 60 * 24 // 1 day
+	AccessTokenLifespan   = 60 * 60 * 24 // 1 day
+	SsoSessionIdleTimeout = 60 * 60 * 24 // 1 day
+	SsoSessionMaxLifespan = 60 * 60 * 24 // 1 day
 )

--- a/internal/keycloak/keycloak.go
+++ b/internal/keycloak/keycloak.go
@@ -927,9 +927,9 @@ func defaultRealmSetting(realmId string) gocloak.RealmRepresentation {
 	return gocloak.RealmRepresentation{
 		Realm:                 gocloak.StringP(realmId),
 		Enabled:               gocloak.BoolP(true),
-		AccessTokenLifespan:   gocloak.IntP(accessTokenLifespan),
-		SsoSessionIdleTimeout: gocloak.IntP(ssoSessionIdleTimeout),
-		SsoSessionMaxLifespan: gocloak.IntP(ssoSessionMaxLifespan),
+		AccessTokenLifespan:   gocloak.IntP(AccessTokenLifespan),
+		SsoSessionIdleTimeout: gocloak.IntP(SsoSessionIdleTimeout),
+		SsoSessionMaxLifespan: gocloak.IntP(SsoSessionMaxLifespan),
 	}
 }
 

--- a/internal/middleware/auth/authenticator/custom/authenticator.go
+++ b/internal/middleware/auth/authenticator/custom/authenticator.go
@@ -1,0 +1,80 @@
+package custom
+
+import (
+	"fmt"
+	"github.com/openinfradev/tks-api/internal/helper"
+	"github.com/openinfradev/tks-api/internal/middleware/auth/authenticator"
+	"github.com/openinfradev/tks-api/internal/repository"
+	"github.com/openinfradev/tks-api/pkg/httpErrors"
+	"github.com/openinfradev/tks-api/pkg/log"
+	"net/http"
+	"strings"
+)
+
+type CustomAuthenticator struct {
+	repo repository.Repository
+}
+
+func NewCustomAuthenticator(repo repository.Repository) *CustomAuthenticator {
+	return &CustomAuthenticator{
+		repo: repo,
+	}
+}
+func (a *CustomAuthenticator) AuthenticateRequest(r *http.Request) (*authenticator.Response, bool, error) {
+	authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
+	if authHeader == "" {
+		return nil, false, fmt.Errorf("authorizer header is invalid")
+	}
+	parts := strings.SplitN(authHeader, " ", 3)
+	if len(parts) < 2 || strings.ToLower(parts[0]) != "bearer" {
+		return nil, false, fmt.Errorf("authorizer header is invalid")
+	}
+	token := parts[1]
+
+	if len(token) == 0 {
+		// The space before the token case
+		if len(parts) == 3 {
+			log.Warn(r.Context(), "the provided Authorization header contains extra space before the bearer token, and is ignored")
+		}
+		return nil, false, fmt.Errorf("token is empty")
+	}
+
+	parsedToken, err := helper.StringToTokenWithoutVerification(token)
+	if err != nil {
+		return nil, false, httpErrors.NewUnauthorizedError(err, "A_INVALID_TOKEN", "토큰이 유효하지 않습니다.")
+	}
+
+	claims, err := helper.RetrieveClaims(parsedToken)
+	if err != nil {
+		return nil, false, httpErrors.NewUnauthorizedError(err, "A_INVALID_TOKEN", "토큰이 유효하지 않습니다.")
+	}
+
+	organizationId, ok := claims["organization"].(string)
+	if !ok {
+		return nil, false, httpErrors.NewUnauthorizedError(fmt.Errorf("organizationId is not found"), "A_INVALID_TOKEN", "토큰이 유효하지 않습니다.")
+	}
+
+	userId, ok := claims["sub"].(string)
+	if !ok {
+		return nil, false, httpErrors.NewUnauthorizedError(fmt.Errorf("userId is not found"), "A_INVALID_TOKEN", "토큰이 유효하지 않습니다.")
+	}
+
+	expiredTime, err := a.repo.Auth.GetExpiredTimeOnToken(r.Context(), organizationId, userId)
+	if expiredTime == nil {
+		return nil, true, nil
+	}
+	if err != nil {
+		return nil, false, httpErrors.NewUnauthorizedError(err, "A_INVALID_TOKEN", "토큰이 유효하지 않습니다.")
+	}
+
+	iat, ok := claims["iat"].(float64)
+	if !ok {
+		return nil, false, httpErrors.NewUnauthorizedError(fmt.Errorf("iat is not found"), "A_INVALID_TOKEN", "토큰이 유효하지 않습니다.")
+	}
+
+	if int64(iat) < expiredTime.ExpiredTime.Unix() {
+		return nil, false, httpErrors.NewUnauthorizedError(fmt.Errorf("token is changed"), "A_UNUSABLE_TOKEN", "토큰이 변경되었습니다.")
+	}
+
+	return nil, true, nil
+}

--- a/internal/model/auth.go
+++ b/internal/model/auth.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"time"
+)
+
+// Models
+type ExpiredTokenTime struct {
+	gorm.Model
+
+	OrganizationId string `gorm:"index:idx_org_id_subject_id,unique;not null"`
+	SubjectId      string `gorm:"index:idx_org_id_subject_id,unique;not null"`
+	ExpiredTime    time.Time
+}
+
+type CacheEmailCode struct {
+	gorm.Model
+
+	UserId uuid.UUID `gorm:"not null"`
+	Code   string    `gorm:"type:varchar(6);not null"`
+}

--- a/internal/repository/auth.go
+++ b/internal/repository/auth.go
@@ -3,27 +3,23 @@ package repository
 import (
 	"context"
 	"github.com/google/uuid"
+	"github.com/openinfradev/tks-api/internal/model"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"time"
 )
 
 type IAuthRepository interface {
 	CreateEmailCode(ctx context.Context, userId uuid.UUID, code string) error
-	GetEmailCode(ctx context.Context, userId uuid.UUID) (CacheEmailCode, error)
+	GetEmailCode(ctx context.Context, userId uuid.UUID) (model.CacheEmailCode, error)
 	UpdateEmailCode(ctx context.Context, userId uuid.UUID, code string) error
 	DeleteEmailCode(ctx context.Context, userId uuid.UUID) error
+	GetExpiredTimeOnToken(ctx context.Context, organizationId string, userId string) (*model.ExpiredTokenTime, error)
+	UpdateExpiredTimeOnToken(ctx context.Context, organizationId string, userId string) error
 }
 
 type AuthRepository struct {
 	db *gorm.DB
-}
-
-// Models
-
-type CacheEmailCode struct {
-	gorm.Model
-
-	UserId uuid.UUID `gorm:"not null"`
-	Code   string    `gorm:"type:varchar(6);not null"`
 }
 
 func NewAuthRepository(db *gorm.DB) IAuthRepository {
@@ -33,25 +29,44 @@ func NewAuthRepository(db *gorm.DB) IAuthRepository {
 }
 
 func (r *AuthRepository) CreateEmailCode(ctx context.Context, userId uuid.UUID, code string) error {
-	cacheEmailCode := CacheEmailCode{
+	cacheEmailCode := model.CacheEmailCode{
 		UserId: userId,
 		Code:   code,
 	}
 	return r.db.WithContext(ctx).Create(&cacheEmailCode).Error
 }
 
-func (r *AuthRepository) GetEmailCode(ctx context.Context, userId uuid.UUID) (CacheEmailCode, error) {
-	var cacheEmailCode CacheEmailCode
+func (r *AuthRepository) GetEmailCode(ctx context.Context, userId uuid.UUID) (model.CacheEmailCode, error) {
+	var cacheEmailCode model.CacheEmailCode
 	if err := r.db.WithContext(ctx).Where("user_id = ?", userId).First(&cacheEmailCode).Error; err != nil {
-		return CacheEmailCode{}, err
+		return model.CacheEmailCode{}, err
 	}
 	return cacheEmailCode, nil
 }
 
 func (r *AuthRepository) UpdateEmailCode(ctx context.Context, userId uuid.UUID, code string) error {
-	return r.db.WithContext(ctx).Model(&CacheEmailCode{}).Where("user_id = ?", userId).Update("code", code).Error
+	return r.db.WithContext(ctx).Model(&model.CacheEmailCode{}).Where("user_id = ?", userId).Update("code", code).Error
 }
 
 func (r *AuthRepository) DeleteEmailCode(ctx context.Context, userId uuid.UUID) error {
-	return r.db.WithContext(ctx).Unscoped().Where("user_id = ?", userId).Delete(&CacheEmailCode{}).Error
+	return r.db.WithContext(ctx).Unscoped().Where("user_id = ?", userId).Delete(&model.CacheEmailCode{}).Error
+}
+
+func (r *AuthRepository) GetExpiredTimeOnToken(ctx context.Context, organizationId string, userId string) (*model.ExpiredTokenTime, error) {
+	var expiredTokenTime model.ExpiredTokenTime
+	if err := r.db.WithContext(ctx).Where("organization_id = ? AND subject_id = ?", organizationId, userId).First(&expiredTokenTime).Error; err != nil {
+		return nil, err
+	}
+	return &expiredTokenTime, nil
+}
+func (r *AuthRepository) UpdateExpiredTimeOnToken(ctx context.Context, organizationId string, userId string) error {
+	// set expired time to now
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "subject_id"}, {Name: "organization_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"expired_time"}),
+	}).Create(&model.ExpiredTokenTime{
+		SubjectId:      userId,
+		ExpiredTime:    time.Now(),
+		OrganizationId: organizationId,
+	}).Error
 }

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openinfradev/tks-api/internal/keycloak"
 	internalMiddleware "github.com/openinfradev/tks-api/internal/middleware"
 	"github.com/openinfradev/tks-api/internal/middleware/auth/authenticator"
+	authCustom "github.com/openinfradev/tks-api/internal/middleware/auth/authenticator/custom"
 	authKeycloak "github.com/openinfradev/tks-api/internal/middleware/auth/authenticator/keycloak"
 	"github.com/openinfradev/tks-api/internal/middleware/auth/authorizer"
 	"github.com/openinfradev/tks-api/internal/repository"
@@ -83,7 +84,7 @@ func SetupRouter(db *gorm.DB, argoClient argowf.ArgoClient, kc keycloak.IKeycloa
 	}
 
 	customMiddleware := internalMiddleware.NewMiddleware(
-		authenticator.NewAuthenticator(authKeycloak.NewKeycloakAuthenticator(kc)),
+		authenticator.NewAuthenticator(authKeycloak.NewKeycloakAuthenticator(kc), repoFactory, authCustom.NewCustomAuthenticator(repoFactory)),
 		authorizer.NewDefaultAuthorization(repoFactory),
 		requestRecoder.NewDefaultRequestRecoder(),
 		audit.NewDefaultAudit(repoFactory))


### PR DESCRIPTION
TKS 역할 또는 Project 역할 변경 시, 기존 토큰을 사용하여 요청을 전송할 경우 아래와 같이 응답.
{
    "status": 401,
    "code": "A_UNUSABLE_TOKEN",
    "message": "token is changed",
    "text": "토큰이 변경되었습니다."
}

@Siyeop 시엽님, 
기존의 VerifyToken에서 사용되어 alarm을 bypass 할때 사용하였던 error code는 "A_UNUSABLE_TOKEN" -> "A_EXPIRED_TOKEN"로 변경 되었습니다.

Backend:
- 기존 JWT token lib으로 사용하던 "github.com/dgrijalva/jwt-go" -> "github.com/golang-jwt/jwt" 변경
- 보안 취약점이 발견된 후 새로운 유지보수자에 의해 "github.com/golang-jwt/jwt"에서 업데이트가 된다고 하여 변경하였습니다.