### PR TITLE
Add project role to the response of login endpoint

### DIFF
--- a/pkg/domain/auth.go
+++ b/pkg/domain/auth.go
@@ -8,14 +8,26 @@ type LoginRequest struct {
 
 type LoginResponse struct {
 	User struct {
-		AccountId       string               `json:"accountId"`
-		Name            string               `json:"name"`
-		Token           string               `json:"token"`
-		Role            RoleResponse         `json:"role"`
-		Department      string               `json:"department"`
-		Organization    OrganizationResponse `json:"organization"`
-		PasswordExpired bool                 `json:"passwordExpired"`
+		AccountId       string                          `json:"accountId"`
+		Name            string                          `json:"name"`
+		Token           string                          `json:"token"`
+		Role            RoleIdRoleNameResponse          `json:"role"`
+		Projects        []*ProjectIdProjectRoleResponse `json:"projects"`
+		Department      string                          `json:"department"`
+		Organization    OrganizationResponse            `json:"organization"`
+		PasswordExpired bool                            `json:"passwordExpired"`
 	} `json:"user"`
+}
+
+type RoleIdRoleNameResponse struct {
+	ID   string `json:"roleId"`
+	Name string `json:"roleName"`
+}
+
+type ProjectIdProjectRoleResponse struct {
+	ID              string `json:"projectId"`
+	ProjectRoleId   string `json:"projectRoleId"`
+	ProjectRoleName string `json:"projectRoleName"`
 }
 
 type LogoutResponse struct {


### PR DESCRIPTION
변경사항: Login 요청 시, 응답의 body에 자신이 포함된 프로젝트에 대한 역할 정보를 추가하고, role 내부를 단순화 하였습니다.
다음과 같이 응답 되도록 하였습니다.
```json
        "role": {
            "roleId": "9a9f9da7-40ef-46cc-9dc6-70ad7eb70e92",
            "roleName": "admin"
        },
        "projects": [
            {
                "projectId": "53708c3a-5052-42b1-b5b1-19b8155b1f51",
                "projectRoleId": "f4358b4e-adc3-447a-8ad9-c111c4b9a974",
                "projectRoleName": "project-leader"
            },
            {
                "projectId": "609ef798-5d37-4f37-855a-d779f752ecbb",
                "projectRoleId": "2071bd6f-26b3-4c1a-a3ab-439bc89f0011",
                "projectRoleName": "project-member"
            },
            {
                "projectId": "df1ad433-d45a-4536-b8b2-ddf8324b4ae9",
                "projectRoleId": "f4358b4e-adc3-447a-8ad9-c111c4b9a974",
                "projectRoleName": "project-leader"
            }
        ],
```