### PR TITLE
minor fix. Reform response data of Permission APIs

### DIFF
--- a/internal/delivery/http/permission.go
+++ b/internal/delivery/http/permission.go
@@ -39,14 +39,14 @@ func (h PermissionHandler) GetPermissionTemplates(w http.ResponseWriter, r *http
 	permissionSet := model.NewDefaultPermissionSet()
 
 	var out domain.GetPermissionTemplatesResponse
-	out.Permissions = new(domain.PermissionTemplateResponse)
+	out.Permissions = make([]*domain.TemplateResponse, 0)
 
-	out.Permissions.Dashboard = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Dashboard)
-	out.Permissions.Stack = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Stack)
-	out.Permissions.Policy = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Policy)
-	out.Permissions.ProjectManagement = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.ProjectManagement)
-	out.Permissions.Notification = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Notification)
-	out.Permissions.Configuration = convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Configuration)
+	out.Permissions = append(out.Permissions, convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Dashboard))
+	out.Permissions = append(out.Permissions, convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Stack))
+	out.Permissions = append(out.Permissions, convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Policy))
+	out.Permissions = append(out.Permissions, convertModelToPermissionTemplateResponse(r.Context(), permissionSet.ProjectManagement))
+	out.Permissions = append(out.Permissions, convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Notification))
+	out.Permissions = append(out.Permissions, convertModelToPermissionTemplateResponse(r.Context(), permissionSet.Configuration))
 
 	ResponseJSON(w, r, http.StatusOK, out)
 }

--- a/internal/delivery/http/role.go
+++ b/internal/delivery/http/role.go
@@ -306,16 +306,15 @@ func (h RoleHandler) GetPermissionsByRoleId(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var permissionSetResponse domain.PermissionSetResponse
-	permissionSetResponse.Dashboard = convertModelToPermissionResponse(r.Context(), permissionSet.Dashboard)
-	permissionSetResponse.Stack = convertModelToPermissionResponse(r.Context(), permissionSet.Stack)
-	permissionSetResponse.Policy = convertModelToPermissionResponse(r.Context(), permissionSet.Policy)
-	permissionSetResponse.ProjectManagement = convertModelToPermissionResponse(r.Context(), permissionSet.ProjectManagement)
-	permissionSetResponse.Notification = convertModelToPermissionResponse(r.Context(), permissionSet.Notification)
-	permissionSetResponse.Configuration = convertModelToPermissionResponse(r.Context(), permissionSet.Configuration)
-
 	var out domain.GetPermissionsByRoleIdResponse
-	out.Permissions = &permissionSetResponse
+	out.Permissions = make([]*domain.PermissionResponse, 0)
+
+	out.Permissions = append(out.Permissions, convertModelToPermissionResponse(r.Context(), permissionSet.Dashboard))
+	out.Permissions = append(out.Permissions, convertModelToPermissionResponse(r.Context(), permissionSet.Stack))
+	out.Permissions = append(out.Permissions, convertModelToPermissionResponse(r.Context(), permissionSet.Policy))
+	out.Permissions = append(out.Permissions, convertModelToPermissionResponse(r.Context(), permissionSet.ProjectManagement))
+	out.Permissions = append(out.Permissions, convertModelToPermissionResponse(r.Context(), permissionSet.Notification))
+	out.Permissions = append(out.Permissions, convertModelToPermissionResponse(r.Context(), permissionSet.Configuration))
 
 	ResponseJSON(w, r, http.StatusOK, out)
 }
@@ -323,11 +322,11 @@ func (h RoleHandler) GetPermissionsByRoleId(w http.ResponseWriter, r *http.Reque
 func convertModelToPermissionResponse(ctx context.Context, permission *model.Permission) *domain.PermissionResponse {
 	var permissionResponse domain.PermissionResponse
 
-	permissionResponse.ID = permission.ID
 	permissionResponse.Key = permission.Key
 	permissionResponse.Name = permission.Name
 	if permission.IsAllowed != nil {
 		permissionResponse.IsAllowed = permission.IsAllowed
+		permissionResponse.ID = &permission.ID
 	}
 
 	for _, endpoint := range permission.Endpoints {

--- a/internal/delivery/http/user.go
+++ b/internal/delivery/http/user.go
@@ -720,18 +720,16 @@ func (u UserHandler) GetPermissionsByAccountId(w http.ResponseWriter, r *http.Re
 
 	mergedPermissionSet := u.permissionUsecase.MergePermissionWithOrOperator(r.Context(), permissionSets...)
 
-	var permissions domain.MergedPermissionSetResponse
-	permissions.Dashboard = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Dashboard)
-	permissions.Stack = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Stack)
-	permissions.Policy = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Policy)
-	permissions.ProjectManagement = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.ProjectManagement)
-	permissions.Notification = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Notification)
-	permissions.Configuration = convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Configuration)
-
 	var out domain.GetUsersPermissionsResponse
-	out.Permissions = &permissions
-	ResponseJSON(w, r, http.StatusOK, out)
+	out.Permissions = make([]*domain.MergePermissionResponse, 0)
+	out.Permissions = append(out.Permissions, convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Dashboard))
+	out.Permissions = append(out.Permissions, convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Stack))
+	out.Permissions = append(out.Permissions, convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Policy))
+	out.Permissions = append(out.Permissions, convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.ProjectManagement))
+	out.Permissions = append(out.Permissions, convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Notification))
+	out.Permissions = append(out.Permissions, convertModelToMergedPermissionSetResponse(r.Context(), mergedPermissionSet.Configuration))
 
+	ResponseJSON(w, r, http.StatusOK, out)
 }
 
 func convertModelToMergedPermissionSetResponse(ctx context.Context, permission *model.Permission) *domain.MergePermissionResponse {

--- a/pkg/domain/permission.go
+++ b/pkg/domain/permission.go
@@ -5,66 +5,74 @@ import (
 )
 
 type GetPermissionTemplatesResponse struct {
-	Permissions *PermissionTemplateResponse `json:"permissions"`
+	//Permissions *PermissionTemplateResponse `json:"permissions"`
+	Permissions []*TemplateResponse `json:"permissions"`
 }
 
-type PermissionTemplateResponse struct {
-	Dashboard         *TemplateResponse `json:"dashboard,omitempty"`
-	Stack             *TemplateResponse `json:"stack,omitempty"`
-	Policy            *TemplateResponse `json:"policy,omitempty"`
-	ProjectManagement *TemplateResponse `json:"project_management,omitempty"`
-	Notification      *TemplateResponse `json:"notification,omitempty"`
-	Configuration     *TemplateResponse `json:"configuration,omitempty"`
-}
+//type PermissionTemplateResponse struct {
+//	Dashboard         *TemplateResponse `json:"dashboard,omitempty"`
+//	Stack             *TemplateResponse `json:"stack,omitempty"`
+//	Policy            *TemplateResponse `json:"policy,omitempty"`
+//	ProjectManagement *TemplateResponse `json:"project_management,omitempty"`
+//	Notification      *TemplateResponse `json:"notification,omitempty"`
+//	Configuration     *TemplateResponse `json:"configuration,omitempty"`
+//}
 
 type TemplateResponse struct {
 	Name      string              `json:"name"`
 	Key       string              `json:"key"`
-	IsAllowed *bool               `json:"is_allowed,omitempty"`
+	IsAllowed *bool               `json:"isAllowed,omitempty"`
 	Children  []*TemplateResponse `json:"children,omitempty"`
 }
 
 type GetPermissionsByRoleIdResponse struct {
-	Permissions *PermissionSetResponse `json:"permissions"`
+	//Permissions *PermissionSetResponse `json:"permissions"`
+	Permissions []*PermissionResponse `json:"permissions"`
 }
 
-type PermissionSetResponse struct {
-	Dashboard         *PermissionResponse `json:"dashboard,omitempty"`
-	Stack             *PermissionResponse `json:"stack,omitempty"`
-	Policy            *PermissionResponse `json:"policy,omitempty"`
-	ProjectManagement *PermissionResponse `json:"project_management,omitempty"`
-	Notification      *PermissionResponse `json:"notification,omitempty"`
-	Configuration     *PermissionResponse `json:"configuration,omitempty"`
-}
+//type PermissionSetResponse struct {
+//	Dashboard         *PermissionResponse   `json:"dashboard,omitempty"`
+//	Stack             *PermissionResponse   `json:"stack,omitempty"`
+//	Policy            *PermissionResponse   `json:"policy,omitempty"`
+//	ProjectManagement *PermissionResponse   `json:"project_management,omitempty"`
+//	Notification      *PermissionResponse   `json:"notification,omitempty"`
+//	Configuration     *PermissionResponse   `json:"configuration,omitempty"`
+//}
 
 type PermissionResponse struct {
-	ID        uuid.UUID             `json:"ID"`
+	ID        *uuid.UUID            `json:"ID,omitempty"`
 	Name      string                `json:"name"`
 	Key       string                `json:"key"`
-	IsAllowed *bool                 `json:"is_allowed,omitempty"`
+	IsAllowed *bool                 `json:"isAllowed,omitempty"`
 	Endpoints []*EndpointResponse   `json:"endpoints,omitempty"`
 	Children  []*PermissionResponse `json:"children,omitempty"`
 }
 
+type UpdatePermissionUpdateRequest struct {
+	ID        uuid.UUID `json:"ID" validate:"required"`
+	IsAllowed *bool     `json:"isAllowed" validate:"required,oneof=true false"`
+}
+
 type UpdatePermissionsByRoleIdRequest struct {
-	Permissions []*PermissionResponse `json:"permissions"`
+	Permissions []*UpdatePermissionUpdateRequest `json:"permissions"`
 }
 
 type GetUsersPermissionsResponse struct {
-	Permissions *MergedPermissionSetResponse `json:"permissions"`
+	//Permissions *MergedPermissionSetResponse `json:"permissions"`
+	Permissions []*MergePermissionResponse `json:"permissions"`
 }
 
-type MergedPermissionSetResponse struct {
-	Dashboard         *MergePermissionResponse `json:"dashboard,omitempty"`
-	Stack             *MergePermissionResponse `json:"stack,omitempty"`
-	Policy            *MergePermissionResponse `json:"policy,omitempty"`
-	ProjectManagement *MergePermissionResponse `json:"project_management,omitempty"`
-	Notification      *MergePermissionResponse `json:"notification,omitempty"`
-	Configuration     *MergePermissionResponse `json:"configuration,omitempty"`
-}
+//type MergedPermissionSetResponse struct {
+//	Dashboard         *MergePermissionResponse `json:"dashboard,omitempty"`
+//	Stack             *MergePermissionResponse `json:"stack,omitempty"`
+//	Policy            *MergePermissionResponse `json:"policy,omitempty"`
+//	ProjectManagement *MergePermissionResponse `json:"project_management,omitempty"`
+//	Notification      *MergePermissionResponse `json:"notification,omitempty"`
+//	Configuration     *MergePermissionResponse `json:"configuration,omitempty"`
+//}
 
 type MergePermissionResponse struct {
 	Key       string                     `json:"key"`
-	IsAllowed *bool                      `json:"is_allowed,omitempty"`
+	IsAllowed *bool                      `json:"isAllowed,omitempty"`
 	Children  []*MergePermissionResponse `json:"children,omitempty"`
 }


### PR DESCRIPTION
240327일 말씀 주신, Permission 관련 Response Body 변경 건입니다.

- Permissions 배열의 컨텐츠로 "Dashboard, Stack" 과 같은 아우터 key 삭제
- "is_allowed" -> "isAllowed"로 변경

변경 후 형상
```json
{
    "permissions": [
        {
            "key": "DASHBOARD",
            "children": [
                {
                    "key": "DASHBOARD-DASHBOARD",
                    "children": [
                        {
                            "key": "UPDATE",
                            "isAllowed": true
                        },
                        {
                            "key": "READ",
                            "isAllowed": false
                        }
                    ]
                }
            ]
        },
        {...}
    ]
}
```