### PR TITLE
복수개의 TKS Role을 갖도록 User Model 수정

### DIFF
--- a/internal/delivery/api/endpoint.go
+++ b/internal/delivery/api/endpoint.go
@@ -195,6 +195,7 @@ const (
 	UpdateTksRole
 	GetPermissionsByRoleId
 	UpdatePermissionsByRoleId
+	IsRoleNameExisted
 
 	// Permission
 	GetPermissionTemplates

--- a/internal/delivery/api/endpoint.go
+++ b/internal/delivery/api/endpoint.go
@@ -25,6 +25,7 @@ const (
 	ListUser
 	GetUser
 	DeleteUser
+	UpdateUsers
 	UpdateUser
 	ResetPassword
 	CheckId

--- a/internal/delivery/api/endpoint.go
+++ b/internal/delivery/api/endpoint.go
@@ -197,6 +197,9 @@ const (
 	GetPermissionsByRoleId
 	UpdatePermissionsByRoleId
 	IsRoleNameExisted
+	AppendUsersToRole
+	GetUsersInRoleId
+	RemoveUsersFromRole
 
 	// Permission
 	GetPermissionTemplates

--- a/internal/delivery/api/generated_endpoints.go.go
+++ b/internal/delivery/api/generated_endpoints.go.go
@@ -611,6 +611,10 @@ var ApiMap = map[Endpoint]EndpointInfo{
 		Name: "UpdatePermissionsByRoleId", 
 		Group: "Role",
 	},
+    IsRoleNameExisted: {
+		Name: "IsRoleNameExisted", 
+		Group: "Role",
+	},
     GetPermissionTemplates: {
 		Name: "GetPermissionTemplates", 
 		Group: "Permission",
@@ -1130,6 +1134,8 @@ func (e Endpoint) String() string {
 		return "GetPermissionsByRoleId"
 	case UpdatePermissionsByRoleId:
 		return "UpdatePermissionsByRoleId"
+	case IsRoleNameExisted:
+		return "IsRoleNameExisted"
 	case GetPermissionTemplates:
 		return "GetPermissionTemplates"
 	case Admin_CreateUser:
@@ -1546,6 +1552,8 @@ func GetEndpoint(name string) Endpoint {
 		return GetPermissionsByRoleId
 	case "UpdatePermissionsByRoleId":
 		return UpdatePermissionsByRoleId
+	case "IsRoleNameExisted":
+		return IsRoleNameExisted
 	case "GetPermissionTemplates":
 		return GetPermissionTemplates
 	case "Admin_CreateUser":

--- a/internal/delivery/http/auth.go
+++ b/internal/delivery/http/auth.go
@@ -101,6 +101,12 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	if err = serializer.Map(r.Context(), user, &out.User); err != nil {
 		log.Error(r.Context(), err)
 	}
+	for _, role := range user.Roles {
+		out.User.Roles = append(out.User.Roles, domain.SimpleRoleResponse{
+			ID:   role.ID,
+			Name: role.Name,
+		})
+	}
 
 	ResponseJSON(w, r, http.StatusOK, out)
 }

--- a/internal/delivery/http/organization.go
+++ b/internal/delivery/http/organization.go
@@ -112,8 +112,21 @@ func (h *OrganizationHandler) Admin_CreateOrganization(w http.ResponseWriter, r 
 		return
 	}
 
+	user := model.User{
+		Organization: model.Organization{
+			ID: organizationId,
+		},
+		AccountId: input.AdminAccountId,
+		Name:      input.AdminName,
+		Email:     input.AdminEmail,
+		Roles: []model.Role{
+			{
+				ID: adminRoleId,
+			},
+		},
+	}
 	// Admin user 생성
-	admin, err := h.userUsecase.CreateAdmin(r.Context(), organizationId, input.AdminAccountId, input.AdminName, input.AdminEmail)
+	admin, err := h.userUsecase.CreateAdmin(r.Context(), &user)
 	if err != nil {
 		log.Errorf(r.Context(), "error is :%s(%T)", err.Error(), err)
 		ErrorJSON(w, r, err)

--- a/internal/delivery/http/role.go
+++ b/internal/delivery/http/role.go
@@ -24,12 +24,17 @@ type IRoleHandler interface {
 	UpdatePermissionsByRoleId(w http.ResponseWriter, r *http.Request)
 	IsRoleNameExisted(w http.ResponseWriter, r *http.Request)
 
+	GetUsersInRoleId(w http.ResponseWriter, r *http.Request)
+	AppendUsersToRole(w http.ResponseWriter, r *http.Request)
+	RemoveUsersFromRole(w http.ResponseWriter, r *http.Request)
+
 	Admin_ListTksRoles(w http.ResponseWriter, r *http.Request)
 	Admin_GetTksRole(w http.ResponseWriter, r *http.Request)
 }
 
 type RoleHandler struct {
 	roleUsecase       usecase.IRoleUsecase
+	userUsecase       usecase.IUserUsecase
 	permissionUsecase usecase.IPermissionUsecase
 }
 
@@ -37,6 +42,7 @@ func NewRoleHandler(usecase usecase.Usecase) *RoleHandler {
 	return &RoleHandler{
 		roleUsecase:       usecase.Role,
 		permissionUsecase: usecase.Permission,
+		userUsecase:       usecase.User,
 	}
 }
 
@@ -169,15 +175,20 @@ func (h RoleHandler) ListTksRoles(w http.ResponseWriter, r *http.Request) {
 func (h RoleHandler) GetTksRole(w http.ResponseWriter, r *http.Request) {
 	// path parameter
 	vars := mux.Vars(r)
-	var roleId string
+	var organizationId, roleId string
 	if v, ok := vars["roleId"]; !ok {
 		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
 	} else {
 		roleId = v
 	}
+	if v, ok := vars["organizationId"]; !ok {
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
+	} else {
+		organizationId = v
+	}
 
 	// get role
-	role, err := h.roleUsecase.GetTksRole(r.Context(), roleId)
+	role, err := h.roleUsecase.GetTksRole(r.Context(), organizationId, roleId)
 	if err != nil {
 		ErrorJSON(w, r, err)
 		return
@@ -465,15 +476,20 @@ func (h RoleHandler) Admin_GetTksRole(w http.ResponseWriter, r *http.Request) {
 	// Same as GetTksRole
 
 	vars := mux.Vars(r)
-	var roleId string
+	var organizationId, roleId string
 	if v, ok := vars["roleId"]; !ok {
 		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
 	} else {
 		roleId = v
 	}
+	if v, ok := vars["organizationId"]; !ok {
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
+	} else {
+		organizationId = v
+	}
 
 	// get role
-	role, err := h.roleUsecase.GetTksRole(r.Context(), roleId)
+	role, err := h.roleUsecase.GetTksRole(r.Context(), organizationId, roleId)
 	if err != nil {
 		ErrorJSON(w, r, err)
 		return
@@ -532,5 +548,196 @@ func (h RoleHandler) IsRoleNameExisted(w http.ResponseWriter, r *http.Request) {
 	out.IsExist = isExist
 
 	// response
+	ResponseJSON(w, r, http.StatusOK, out)
+}
+
+// AppendUsersToRole godoc
+//
+//	@Tags			Roles
+//	@Summary		Append Users To Role
+//	@Description	Append Users To Role
+//	@Accept			json
+//	@Produce		json
+//	@Param			organizationId	path	string						true	"Organization ID"
+//	@Param			roleId			path	string						true	"Role ID"
+//	@Param			body			body	domain.AppendUsersToRoleRequest	true	"Append Users To Role Request"
+//	@Success		200
+//	@Router			/organizations/{organizationId}/roles/{roleId}/users [post]
+//	@Security		JWT
+func (h RoleHandler) AppendUsersToRole(w http.ResponseWriter, r *http.Request) {
+	// path parameter
+	vars := mux.Vars(r)
+	var organizationId, roleId string
+	if v, ok := vars["organizationId"]; !ok {
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
+		return
+	} else {
+		organizationId = v
+	}
+	if v, ok := vars["roleId"]; !ok {
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
+		return
+	} else {
+		roleId = v
+	}
+
+	// request body
+	input := domain.AppendUsersToRoleRequest{}
+	err := UnmarshalRequestInput(r, &input)
+	if err != nil {
+		ErrorJSON(w, r, err)
+		return
+	}
+
+	for _, user := range input.Users {
+		originUser, err := h.userUsecase.Get(r.Context(), user)
+		if err != nil {
+			ErrorJSON(w, r, err)
+			return
+		}
+
+		role, err := h.roleUsecase.GetTksRole(r.Context(), organizationId, roleId)
+		if err != nil {
+			ErrorJSON(w, r, err)
+			return
+		}
+
+		originUser.Roles = append(originUser.Roles, *role)
+
+		if _, err := h.userUsecase.UpdateByAccountIdByAdmin(r.Context(), originUser); err != nil {
+			ErrorJSON(w, r, err)
+			return
+		}
+	}
+
+	// response
+	ResponseJSON(w, r, http.StatusOK, nil)
+}
+
+// RemoveUsersFromRole godoc
+//
+//	@Tags			Roles
+//	@Summary		Remove Users From Role
+//	@Description	Remove Users From Role
+//	@Accept			json
+//	@Produce		json
+//	@Param			organizationId	path	string							true	"Organization ID"
+//	@Param			roleId			path	string							true	"Role ID"
+//	@Param			body			body	domain.RemoveUsersFromRoleRequest	true	"Remove Users From Role Request"
+//	@Success		200
+//	@Router			/organizations/{organizationId}/roles/{roleId}/users [delete]
+//	@Security		JWT
+func (h RoleHandler) RemoveUsersFromRole(w http.ResponseWriter, r *http.Request) {
+	// path parameter
+	vars := mux.Vars(r)
+	var organizationId, roleId string
+	if v, ok := vars["organizationId"]; !ok {
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
+		return
+	} else {
+		organizationId = v
+	}
+	if v, ok := vars["roleId"]; !ok {
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
+		return
+	} else {
+		roleId = v
+	}
+
+	// request body
+	input := domain.RemoveUsersFromRoleRequest{}
+	err := UnmarshalRequestInput(r, &input)
+	if err != nil {
+		ErrorJSON(w, r, err)
+		return
+	}
+
+	for _, user := range input.Users {
+		originUser, err := h.userUsecase.Get(r.Context(), user)
+		if err != nil {
+			ErrorJSON(w, r, err)
+			return
+		}
+
+		role, err := h.roleUsecase.GetTksRole(r.Context(), organizationId, roleId)
+		if err != nil {
+			ErrorJSON(w, r, err)
+			return
+		}
+
+		for i, r := range originUser.Roles {
+			if r.ID == role.ID {
+				originUser.Roles = append(originUser.Roles[:i], originUser.Roles[i+1:]...)
+				break
+			}
+		}
+
+		if _, err := h.userUsecase.UpdateByAccountIdByAdmin(r.Context(), originUser); err != nil {
+			ErrorJSON(w, r, err)
+			return
+		}
+	}
+
+	// response
+	ResponseJSON(w, r, http.StatusOK, nil)
+}
+
+// GetUsersInRoleId godoc
+//
+//	@Tags			Roles
+//	@Summary		Get Users By Role ID
+//	@Description	Get Users By Role ID
+//	@Produce		json
+//	@Param			organizationId	path	string	true	"Organization ID"
+//	@Param			roleId			path	string	true	"Role ID"
+//	@Param			pageSize		query		string		false	"pageSize"
+//	@Param			pageNumber		query		string		false	"pageNumber"
+//	@Param			soertColumn		query		string		false	"sortColumn"
+//	@Param			sortOrder		query		string		false	"sortOrder"
+//	@Param			filters			query		[]string	false	"filters"
+//	@Success		200 {object} domain.GetUsersInRoleIdResponse
+//	@Router			/organizations/{organizationId}/roles/{roleId}/users [get]
+//	@Security		JWT
+func (h RoleHandler) GetUsersInRoleId(w http.ResponseWriter, r *http.Request) {
+	// path parameter
+	vars := mux.Vars(r)
+	var organizationId, roleId string
+	if v, ok := vars["roleId"]; !ok {
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
+		return
+	} else {
+		roleId = v
+	}
+	if v, ok := vars["organizationId"]; !ok {
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
+		return
+	} else {
+		organizationId = v
+	}
+
+	urlParams := r.URL.Query()
+	pg := pagination.NewPagination(&urlParams)
+	users, err := h.userUsecase.ListUsersByRole(r.Context(), organizationId, roleId, pg)
+	if err != nil {
+		ErrorJSON(w, r, err)
+		return
+	}
+
+	var out domain.GetUsersInRoleIdResponse
+	out.Users = make([]domain.SimpleUserResponse, len(*users))
+	for i, user := range *users {
+		out.Users[i] = domain.SimpleUserResponse{
+			ID:         user.ID.String(),
+			AccountId:  user.AccountId,
+			Name:       user.Name,
+			Email:      user.Email,
+			Department: user.Department,
+		}
+	}
+
+	if err := serializer.Map(r.Context(), *pg, &out.Pagination); err != nil {
+		log.Info(r.Context(), err)
+	}
+
 	ResponseJSON(w, r, http.StatusOK, out)
 }

--- a/internal/delivery/http/role.go
+++ b/internal/delivery/http/role.go
@@ -219,8 +219,16 @@ func (h RoleHandler) DeleteTksRole(w http.ResponseWriter, r *http.Request) {
 		roleId = v
 	}
 
+	var organizationId string
+	if v, ok := vars["organizationId"]; !ok {
+		ErrorJSON(w, r, httpErrors.NewBadRequestError(nil, "", ""))
+		return
+	} else {
+		organizationId = v
+	}
+
 	// delete role
-	if err := h.roleUsecase.DeleteTksRole(r.Context(), roleId); err != nil {
+	if err := h.roleUsecase.DeleteTksRole(r.Context(), organizationId, roleId); err != nil {
 		ErrorJSON(w, r, err)
 		return
 	}

--- a/internal/delivery/http/user.go
+++ b/internal/delivery/http/user.go
@@ -100,7 +100,7 @@ func (u UserHandler) Create(w http.ResponseWriter, r *http.Request) {
 		ID: organizationId,
 	}
 	for _, role := range input.Roles {
-		v, err := u.roleUsecase.GetTksRole(ctx, *role.ID)
+		v, err := u.roleUsecase.GetTksRole(ctx, organizationId, *role.ID)
 		if err != nil {
 			ErrorJSON(w, r, err)
 			return
@@ -329,7 +329,7 @@ func (u UserHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	user.AccountId = accountId
 	for _, role := range input.Roles {
-		v, err := u.roleUsecase.GetTksRole(ctx, *role.ID)
+		v, err := u.roleUsecase.GetTksRole(ctx, organizationId, *role.ID)
 		if err != nil {
 			ErrorJSON(w, r, err)
 			return
@@ -403,7 +403,7 @@ func (u UserHandler) UpdateUsers(w http.ResponseWriter, r *http.Request) {
 		users[i].AccountId = user.AccountId
 
 		for _, role := range user.Roles {
-			v, err := u.roleUsecase.GetTksRole(ctx, *role.ID)
+			v, err := u.roleUsecase.GetTksRole(ctx, organizationId, *role.ID)
 			if err != nil {
 				ErrorJSON(w, r, err)
 				return
@@ -888,7 +888,7 @@ func (u UserHandler) Admin_Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, role := range input.Roles {
-		v, err := u.roleUsecase.GetTksRole(r.Context(), *role.ID)
+		v, err := u.roleUsecase.GetTksRole(r.Context(), organizationId, *role.ID)
 		if err != nil {
 			ErrorJSON(w, r, err)
 			return

--- a/internal/helper/util.go
+++ b/internal/helper/util.go
@@ -93,3 +93,12 @@ func StringP(value string) *string {
 func UUIDP(value uuid.UUID) *uuid.UUID {
 	return &value
 }
+
+func DeepCopy(src, dest interface{}) error {
+	bytes, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(bytes, dest)
+}

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -12,8 +12,7 @@ type User struct {
 	Password          string    `gorm:"-:all" json:"password"`
 	Name              string    `json:"name"`
 	Token             string    `json:"token"`
-	RoleId            string
-	Role              Role `gorm:"foreignKey:RoleId;references:ID" json:"role"`
+	Roles             []Role    `gorm:"many2many:user_roles;" json:"roles"`
 	OrganizationId    string
 	Organization      Organization `gorm:"foreignKey:OrganizationId;references:ID" json:"organization"`
 	Creator           string       `json:"creator"`

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"gorm.io/gorm"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,4 +25,12 @@ type User struct {
 	Email       string `json:"email"`
 	Department  string `json:"department"`
 	Description string `json:"description"`
+}
+
+func (u *User) BeforeDelete(db *gorm.DB) (err error) {
+	err = db.Table("user_roles").Unscoped().Where("user_id = ?", u.ID).Delete(nil).Error
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/repository/role.go
+++ b/internal/repository/role.go
@@ -41,7 +41,9 @@ func (r RoleRepository) Create(ctx context.Context, roleObj *model.Role) (string
 	if roleObj == nil {
 		return "", fmt.Errorf("roleObj is nil")
 	}
-	roleObj.ID = uuid.New().String()
+	if roleObj.ID == "" {
+		roleObj.ID = uuid.New().String()
+	}
 	if err := r.db.WithContext(ctx).Create(roleObj).Error; err != nil {
 		return "", err
 	}

--- a/internal/repository/role.go
+++ b/internal/repository/role.go
@@ -15,7 +15,7 @@ import (
 type IRoleRepository interface {
 	Create(ctx context.Context, roleObj *model.Role) (string, error)
 	ListTksRoles(ctx context.Context, organizationId string, pg *pagination.Pagination) ([]*model.Role, error)
-	GetTksRole(ctx context.Context, id string) (*model.Role, error)
+	GetTksRole(ctx context.Context, organizationId string, id string) (*model.Role, error)
 	GetTksRoleByRoleName(ctx context.Context, organizationId string, roleName string) (*model.Role, error)
 	Delete(ctx context.Context, id string) error
 	Update(ctx context.Context, roleObj *model.Role) error
@@ -65,7 +65,7 @@ func (r RoleRepository) ListTksRoles(ctx context.Context, organizationId string,
 	return roles, nil
 }
 
-func (r RoleRepository) GetTksRole(ctx context.Context, id string) (*model.Role, error) {
+func (r RoleRepository) GetTksRole(ctx context.Context, organizationId string, id string) (*model.Role, error) {
 	var role model.Role
 	if err := r.db.WithContext(ctx).First(&role, "id = ?", id).Error; err != nil {
 		return nil, err

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -227,7 +227,13 @@ func (r *UserRepository) UpdatePasswordAt(ctx context.Context, userId uuid.UUID,
 }
 
 func (r *UserRepository) DeleteWithUuid(ctx context.Context, uuid uuid.UUID) error {
-	res := r.db.WithContext(ctx).Unscoped().Delete(&model.User{}, "id = ?", uuid)
+	var user model.User
+	if err := r.db.WithContext(ctx).Model(&model.User{}).Preload("Organization").Preload("Roles").Find(&user, "id = ?", uuid).Error; err != nil {
+		log.Errorf(ctx, "error is :%s(%T)", err.Error(), err)
+		return err
+	}
+
+	res := r.db.WithContext(ctx).Unscoped().Delete(&user)
 	if res.Error != nil {
 		log.Errorf(ctx, "error is :%s(%T)", res.Error.Error(), res.Error)
 		return res.Error

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -293,6 +293,9 @@ func SetupRouter(db *gorm.DB, argoClient argowf.ArgoClient, kc keycloak.IKeycloa
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleId}/permissions", customMiddleware.Handle(internalApi.GetPermissionsByRoleId, http.HandlerFunc(roleHandler.GetPermissionsByRoleId))).Methods(http.MethodGet)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleId}/permissions", customMiddleware.Handle(internalApi.UpdatePermissionsByRoleId, http.HandlerFunc(roleHandler.UpdatePermissionsByRoleId))).Methods(http.MethodPut)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleName}/existence", customMiddleware.Handle(internalApi.IsRoleNameExisted, http.HandlerFunc(roleHandler.IsRoleNameExisted))).Methods(http.MethodGet)
+	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleId}/users", customMiddleware.Handle(internalApi.AppendUsersToRole, http.HandlerFunc(roleHandler.AppendUsersToRole))).Methods(http.MethodPost)
+	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleId}/users", customMiddleware.Handle(internalApi.GetUsersInRoleId, http.HandlerFunc(roleHandler.GetUsersInRoleId))).Methods(http.MethodGet)
+	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleId}/users", customMiddleware.Handle(internalApi.RemoveUsersFromRole, http.HandlerFunc(roleHandler.RemoveUsersFromRole))).Methods(http.MethodDelete)
 
 	// Admin
 	r.Handle(API_PREFIX+API_VERSION+ADMINAPI_PREFIX+"/organizations/{organizationId}/roles", customMiddleware.Handle(internalApi.Admin_ListTksRoles, http.HandlerFunc(roleHandler.Admin_ListTksRoles))).Methods(http.MethodGet)

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -79,7 +79,7 @@ func SetupRouter(db *gorm.DB, argoClient argowf.ArgoClient, kc keycloak.IKeycloa
 		Stack:                      usecase.NewStackUsecase(repoFactory, argoClient, usecase.NewDashboardUsecase(repoFactory, cache)),
 		Project:                    usecase.NewProjectUsecase(repoFactory, kc, argoClient),
 		Audit:                      usecase.NewAuditUsecase(repoFactory),
-		Role:                       usecase.NewRoleUsecase(repoFactory),
+		Role:                       usecase.NewRoleUsecase(repoFactory, kc),
 		Permission:                 usecase.NewPermissionUsecase(repoFactory),
 		PolicyTemplate:             usecase.NewPolicyTemplateUsecase(repoFactory),
 		Policy:                     usecase.NewPolicyUsecase(repoFactory),

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -291,6 +291,7 @@ func SetupRouter(db *gorm.DB, argoClient argowf.ArgoClient, kc keycloak.IKeycloa
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleId}", customMiddleware.Handle(internalApi.UpdateTksRole, http.HandlerFunc(roleHandler.UpdateTksRole))).Methods(http.MethodPut)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleId}/permissions", customMiddleware.Handle(internalApi.GetPermissionsByRoleId, http.HandlerFunc(roleHandler.GetPermissionsByRoleId))).Methods(http.MethodGet)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleId}/permissions", customMiddleware.Handle(internalApi.UpdatePermissionsByRoleId, http.HandlerFunc(roleHandler.UpdatePermissionsByRoleId))).Methods(http.MethodPut)
+	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/roles/{roleName}/existence", customMiddleware.Handle(internalApi.IsRoleNameExisted, http.HandlerFunc(roleHandler.IsRoleNameExisted))).Methods(http.MethodGet)
 
 	// Admin
 	r.Handle(API_PREFIX+API_VERSION+ADMINAPI_PREFIX+"/organizations/{organizationId}/roles", customMiddleware.Handle(internalApi.Admin_ListTksRoles, http.HandlerFunc(roleHandler.Admin_ListTksRoles))).Methods(http.MethodGet)

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -112,6 +112,7 @@ func SetupRouter(db *gorm.DB, argoClient argowf.ArgoClient, kc keycloak.IKeycloa
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/users", customMiddleware.Handle(internalApi.CreateUser, http.HandlerFunc(userHandler.Create))).Methods(http.MethodPost)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/users", customMiddleware.Handle(internalApi.ListUser, http.HandlerFunc(userHandler.List))).Methods(http.MethodGet)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/users/{accountId}", customMiddleware.Handle(internalApi.GetUser, http.HandlerFunc(userHandler.Get))).Methods(http.MethodGet)
+	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/users", customMiddleware.Handle(internalApi.UpdateUsers, http.HandlerFunc(userHandler.UpdateUsers))).Methods(http.MethodPut)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/users/{accountId}", customMiddleware.Handle(internalApi.UpdateUser, http.HandlerFunc(userHandler.Update))).Methods(http.MethodPut)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/users/{accountId}/reset-password", customMiddleware.Handle(internalApi.ResetPassword, http.HandlerFunc(userHandler.ResetPassword))).Methods(http.MethodPut)
 	r.Handle(API_PREFIX+API_VERSION+"/organizations/{organizationId}/users/{accountId}", customMiddleware.Handle(internalApi.DeleteUser, http.HandlerFunc(userHandler.Delete))).Methods(http.MethodDelete)

--- a/internal/usecase/role.go
+++ b/internal/usecase/role.go
@@ -1,8 +1,8 @@
 package usecase
 
 import (
-	"github.com/openinfradev/tks-api/internal/model"
 	"context"
+	"github.com/openinfradev/tks-api/internal/model"
 	"github.com/openinfradev/tks-api/internal/pagination"
 	"github.com/openinfradev/tks-api/internal/repository"
 )
@@ -13,6 +13,7 @@ type IRoleUsecase interface {
 	GetTksRole(ctx context.Context, id string) (*model.Role, error)
 	DeleteTksRole(ctx context.Context, id string) error
 	UpdateTksRole(ctx context.Context, role *model.Role) error
+	IsRoleNameExisted(ctx context.Context, organizationId string, roleName string) (bool, error)
 }
 
 type RoleUsecase struct {
@@ -58,4 +59,17 @@ func (r RoleUsecase) UpdateTksRole(ctx context.Context, role *model.Role) error 
 	}
 
 	return nil
+}
+
+func (r RoleUsecase) IsRoleNameExisted(ctx context.Context, organizationId string, roleName string) (bool, error) {
+	role, err := r.repo.GetTksRoleByRoleName(ctx, organizationId, roleName)
+	if err != nil {
+		return false, err
+	}
+
+	if role != nil {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/internal/usecase/role.go
+++ b/internal/usecase/role.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"github.com/openinfradev/tks-api/internal/keycloak"
 	"github.com/openinfradev/tks-api/internal/model"
 	"github.com/openinfradev/tks-api/internal/pagination"
 	"github.com/openinfradev/tks-api/internal/repository"
@@ -11,22 +12,29 @@ type IRoleUsecase interface {
 	CreateTksRole(ctx context.Context, role *model.Role) (string, error)
 	ListTksRoles(ctx context.Context, organizationId string, pg *pagination.Pagination) ([]*model.Role, error)
 	GetTksRole(ctx context.Context, id string) (*model.Role, error)
-	DeleteTksRole(ctx context.Context, id string) error
+	DeleteTksRole(ctx context.Context, organizationId string, id string) error
 	UpdateTksRole(ctx context.Context, role *model.Role) error
 	IsRoleNameExisted(ctx context.Context, organizationId string, roleName string) (bool, error)
 }
 
 type RoleUsecase struct {
 	repo repository.IRoleRepository
+	kc   keycloak.IKeycloak
 }
 
-func NewRoleUsecase(repo repository.Repository) *RoleUsecase {
+func NewRoleUsecase(repo repository.Repository, kc keycloak.IKeycloak) *RoleUsecase {
 	return &RoleUsecase{
 		repo: repo.Role,
+		kc:   kc,
 	}
 }
 
 func (r RoleUsecase) CreateTksRole(ctx context.Context, role *model.Role) (string, error) {
+	roleId, err := r.kc.CreateGroup(ctx, role.OrganizationID, role.Name)
+	if err != nil {
+		return "", err
+	}
+	role.ID = roleId
 	return r.repo.Create(ctx, role)
 }
 
@@ -48,7 +56,11 @@ func (r RoleUsecase) GetTksRole(ctx context.Context, id string) (*model.Role, er
 	return role, nil
 }
 
-func (r RoleUsecase) DeleteTksRole(ctx context.Context, id string) error {
+func (r RoleUsecase) DeleteTksRole(ctx context.Context, organizationId string, id string) error {
+	err := r.kc.DeleteGroup(ctx, organizationId, id)
+	if err != nil {
+		return err
+	}
 	return r.repo.Delete(ctx, id)
 }
 

--- a/internal/usecase/role.go
+++ b/internal/usecase/role.go
@@ -11,7 +11,7 @@ import (
 type IRoleUsecase interface {
 	CreateTksRole(ctx context.Context, role *model.Role) (string, error)
 	ListTksRoles(ctx context.Context, organizationId string, pg *pagination.Pagination) ([]*model.Role, error)
-	GetTksRole(ctx context.Context, id string) (*model.Role, error)
+	GetTksRole(ctx context.Context, orgainzationId string, id string) (*model.Role, error)
 	DeleteTksRole(ctx context.Context, organizationId string, id string) error
 	UpdateTksRole(ctx context.Context, role *model.Role) error
 	IsRoleNameExisted(ctx context.Context, organizationId string, roleName string) (bool, error)
@@ -47,8 +47,8 @@ func (r RoleUsecase) ListTksRoles(ctx context.Context, organizationId string, pg
 	return roles, nil
 }
 
-func (r RoleUsecase) GetTksRole(ctx context.Context, id string) (*model.Role, error) {
-	role, err := r.repo.GetTksRole(ctx, id)
+func (r RoleUsecase) GetTksRole(ctx context.Context, organizationId string, id string) (*model.Role, error) {
+	role, err := r.repo.GetTksRole(ctx, organizationId, id)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/user.go
+++ b/internal/usecase/user.go
@@ -19,14 +19,14 @@ import (
 )
 
 type IUserUsecase interface {
-	CreateAdmin(ctx context.Context, organizationId string, accountId string, accountName string, email string) (*model.User, error)
+	CreateAdmin(ctx context.Context, user *model.User) (*model.User, error)
 	DeleteAdmin(ctx context.Context, organizationId string) error
 	DeleteAll(ctx context.Context, organizationId string) error
 	Create(ctx context.Context, user *model.User) (*model.User, error)
 	List(ctx context.Context, organizationId string) (*[]model.User, error)
 	ListWithPagination(ctx context.Context, organizationId string, pg *pagination.Pagination) (*[]model.User, error)
 	Get(ctx context.Context, userId uuid.UUID) (*model.User, error)
-	Update(ctx context.Context, userId uuid.UUID, user *model.User) (*model.User, error)
+	Update(ctx context.Context, user *model.User) (*model.User, error)
 	ResetPassword(ctx context.Context, userId uuid.UUID) error
 	ResetPasswordByAccountId(ctx context.Context, accountId string, organizationId string) error
 	GenerateRandomPassword(ctx context.Context) string
@@ -35,7 +35,7 @@ type IUserUsecase interface {
 	GetByEmail(ctx context.Context, email string, organizationId string) (*model.User, error)
 	SendEmailForTemporaryPassword(ctx context.Context, accountId string, organizationId string, password string) error
 
-	UpdateByAccountId(ctx context.Context, accountId string, user *model.User) (*model.User, error)
+	UpdateByAccountId(ctx context.Context, user *model.User) (*model.User, error)
 	UpdatePasswordByAccountId(ctx context.Context, accountId string, originPassword string, newPassword string, organizationId string) error
 	RenewalPasswordExpiredTime(ctx context.Context, userId uuid.UUID) error
 	RenewalPasswordExpiredTimeByAccountId(ctx context.Context, accountId string, organizationId string) error
@@ -43,7 +43,7 @@ type IUserUsecase interface {
 	ValidateAccount(ctx context.Context, userId uuid.UUID, password string, organizationId string) error
 	ValidateAccountByAccountId(ctx context.Context, accountId string, password string, organizationId string) error
 
-	UpdateByAccountIdByAdmin(ctx context.Context, accountId string, user *model.User) (*model.User, error)
+	UpdateByAccountIdByAdmin(ctx context.Context, user *model.User) (*model.User, error)
 }
 
 type UserUsecase struct {
@@ -197,34 +197,23 @@ func (u *UserUsecase) DeleteAdmin(ctx context.Context, organizationId string) er
 	return nil
 }
 
-func (u *UserUsecase) CreateAdmin(ctx context.Context, organizationId string, accountId string, accountName string, email string) (*model.User, error) {
+func (u *UserUsecase) CreateAdmin(ctx context.Context, user *model.User) (*model.User, error) {
 	// Generate Admin user object
 	randomPassword := helper.GenerateRandomString(passwordLength)
-	user := model.User{
-		AccountId: accountId,
-		Password:  randomPassword,
-		Email:     email,
-		Role: model.Role{
-			Name: "admin",
-		},
-		Organization: model.Organization{
-			ID: organizationId,
-		},
-		Name: accountName,
-	}
+	user.Password = randomPassword
 
 	// Create Admin user in keycloak & DB
-	resUser, err := u.Create(context.Background(), &user)
+	resUser, err := u.Create(context.Background(), user)
 	if err != nil {
 		return nil, err
 	}
 
 	// Send mail of temporary password
-	organizationInfo, err := u.organizationRepository.Get(ctx, organizationId)
+	organizationInfo, err := u.organizationRepository.Get(ctx, resUser.Organization.ID)
 	if err != nil {
 		return nil, err
 	}
-	message, err := mail.MakeGeneratingOrganizationMessage(ctx, organizationId, organizationInfo.Name, user.Email, user.AccountId, randomPassword)
+	message, err := mail.MakeGeneratingOrganizationMessage(ctx, resUser.Organization.ID, organizationInfo.Name, user.Email, user.AccountId, randomPassword)
 	if err != nil {
 		return nil, httpErrors.NewInternalServerError(err, "", "")
 	}
@@ -346,35 +335,19 @@ func (u *UserUsecase) GetByEmail(ctx context.Context, email string, organization
 	return &(*users)[0], nil
 }
 
-func (u *UserUsecase) Update(ctx context.Context, userId uuid.UUID, user *model.User) (*model.User, error) {
-	storedUser, err := u.Get(ctx, userId)
+func (u *UserUsecase) Update(ctx context.Context, user *model.User) (*model.User, error) {
+	storedUser, err := u.Get(ctx, user.ID)
 	if err != nil {
 		return nil, err
 	}
 	user.AccountId = storedUser.AccountId
 
-	return u.UpdateByAccountId(ctx, storedUser.AccountId, user)
+	return u.UpdateByAccountId(ctx, user)
 }
 
-func (u *UserUsecase) UpdateByAccountId(ctx context.Context, accountId string, user *model.User) (*model.User, error) {
-	var out model.User
-
-	originUser, err := u.kc.GetUser(ctx, user.Organization.ID, accountId)
-	if err != nil {
-		return nil, err
-	}
-
-	if (originUser.Email == nil || *originUser.Email != user.Email) || (originUser.FirstName == nil || *originUser.FirstName != user.Name) {
-		originUser.Email = gocloak.StringP(user.Email)
-		originUser.FirstName = gocloak.StringP(user.Name)
-		err = u.kc.UpdateUser(ctx, user.Organization.ID, originUser)
-		if err != nil {
-			return nil, err
-		}
-	}
-
+func (u *UserUsecase) UpdateByAccountId(ctx context.Context, user *model.User) (*model.User, error) {
 	users, err := u.userRepository.List(ctx, u.userRepository.OrganizationFilter(user.Organization.ID),
-		u.userRepository.AccountIdFilter(accountId))
+		u.userRepository.AccountIdFilter(user.AccountId))
 	if err != nil {
 		if _, code := httpErrors.ErrorResponse(err); code == http.StatusNotFound {
 			return nil, httpErrors.NewNotFoundError(httpErrors.NotFound, "", "")
@@ -387,17 +360,22 @@ func (u *UserUsecase) UpdateByAccountId(ctx context.Context, accountId string, u
 		return nil, fmt.Errorf("multiple users found")
 	}
 
-	roleUuid := (*users)[0].Role.ID
-	if err != nil {
-		return nil, err
+	if ((*users)[0].Email != user.Email) || ((*users)[0].Name != user.Name) {
+		err = u.kc.UpdateUser(ctx, user.Organization.ID, &gocloak.User{
+			Email:     gocloak.StringP(user.Email),
+			FirstName: gocloak.StringP(user.Name),
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	out, err = u.userRepository.UpdateWithUuid(ctx, (*users)[0].ID, user.AccountId, user.Name, roleUuid, user.Email, user.Department, user.Description)
+	resp, err := u.userRepository.Update(ctx, user)
 	if err != nil {
 		return nil, errors.Wrap(err, "updating user in repository failed")
 	}
 
-	return &out, nil
+	return resp, nil
 }
 
 func (u *UserUsecase) Delete(ctx context.Context, userId uuid.UUID, organizationId string) error {
@@ -441,7 +419,11 @@ func (u *UserUsecase) DeleteByAccountId(ctx context.Context, accountId string, o
 
 func (u *UserUsecase) Create(ctx context.Context, user *model.User) (*model.User, error) {
 	// Create user in keycloak
-	groups := []string{fmt.Sprintf("%s@%s", user.Role.Name, user.Organization.ID)}
+	var groups []string
+	for _, role := range user.Roles {
+		groups = append(groups, fmt.Sprintf("%s@%s", role.Name, user.Organization.ID))
+	}
+
 	userUuidStr, err := u.kc.CreateUser(ctx, user.Organization.ID, &gocloak.User{
 		Username: gocloak.StringP(user.AccountId),
 		Credentials: &[]gocloak.CredentialRepresentation{
@@ -459,76 +441,69 @@ func (u *UserUsecase) Create(ctx context.Context, user *model.User) (*model.User
 		return nil, err
 	}
 
-	// Get user role
-	var roleUuid string
-	roles, err := u.roleRepository.ListTksRoles(ctx, user.Organization.ID, nil)
-	if err != nil {
-		return nil, err
-	}
-	if len(roles) == 0 {
-		return nil, httpErrors.NewInternalServerError(fmt.Errorf("role not found"), "", "")
-	}
-	for _, role := range roles {
-		if role.Name == user.Role.Name {
-			roleUuid = role.ID
-		}
-	}
-	if roleUuid == "" {
-		return nil, httpErrors.NewInternalServerError(fmt.Errorf("role not found"), "", "")
-	}
-
-	// Generate user uuid
-	userUuid, err := uuid.Parse(userUuidStr)
-	if err != nil {
+	if user.ID, err = uuid.Parse(userUuidStr); err != nil {
 		return nil, err
 	}
 
 	// Create user in DB
-	resUser, err := u.userRepository.CreateWithUuid(ctx, userUuid, user.AccountId, user.Name, user.Email,
-		user.Department, user.Description, user.Organization.ID, roleUuid)
+	resUser, err := u.userRepository.Create(ctx, user)
+	//resUser, err := u.userRepository.Create(ctx, userUuid, user.AccountId, user.Name, user.Email,
+	//	user.Department, user.Description, user.Organization.ID, roleUuid)
 	if err != nil {
 		return nil, err
 	}
 
-	return &resUser, nil
+	return resUser, nil
 }
 
-func (u *UserUsecase) UpdateByAccountIdByAdmin(ctx context.Context, accountId string, newUser *model.User) (*model.User, error) {
+func (u *UserUsecase) UpdateByAccountIdByAdmin(ctx context.Context, newUser *model.User) (*model.User, error) {
+	if newUser.AccountId == "" {
+		return nil, httpErrors.NewBadRequestError(fmt.Errorf("accountId is required"), "C_INVALID_ACCOUNT_ID", "")
+	}
+
 	deepCopyUser := *newUser
-	user, err := u.UpdateByAccountId(ctx, accountId, &deepCopyUser)
+	user, err := u.UpdateByAccountId(ctx, &deepCopyUser)
 	if err != nil {
 		return nil, err
 	}
 
-	if newUser.Role.Name != user.Role.Name {
-		originGroupName := fmt.Sprintf("%s@%s", user.Role.Name, newUser.Organization.ID)
-		newGroupName := fmt.Sprintf("%s@%s", newUser.Role.Name, newUser.Organization.ID)
-		if err := u.kc.LeaveGroup(ctx, newUser.Organization.ID, user.ID.String(), originGroupName); err != nil {
+	var unassigningRoleIds, assigningRoleIds map[string]struct{}
+	for _, role := range newUser.Roles {
+		assigningRoleIds[role.ID] = struct{}{}
+	}
+	for _, role := range user.Roles {
+		if _, ok := assigningRoleIds[role.ID]; !ok {
+			unassigningRoleIds[role.ID] = struct{}{}
+		} else {
+			delete(assigningRoleIds, role.ID)
+		}
+	}
+
+	for roleId := range unassigningRoleIds {
+		groupName := fmt.Sprintf("%s@%s", roleId, user.Organization.ID)
+		if err := u.kc.LeaveGroup(ctx, user.Organization.ID, user.ID.String(), groupName); err != nil {
 			log.Errorf(ctx, "leave group in keycloak failed: %v", err)
 			return nil, httpErrors.NewInternalServerError(err, "", "")
 		}
-		if err := u.kc.JoinGroup(ctx, newUser.Organization.ID, user.ID.String(), newGroupName); err != nil {
+	}
+
+	for roleId := range assigningRoleIds {
+		groupName := fmt.Sprintf("%s@%s", roleId, user.Organization.ID)
+		if err := u.kc.JoinGroup(ctx, user.Organization.ID, user.ID.String(), groupName); err != nil {
 			log.Errorf(ctx, "join group in keycloak failed: %v", err)
 			return nil, httpErrors.NewInternalServerError(err, "", "")
 		}
-
-		targetUser, err := u.userRepository.Get(ctx, newUser.AccountId, newUser.Organization.ID)
-		if err != nil {
-			return nil, err
-		}
-		err = u.authRepository.UpdateExpiredTimeOnToken(ctx, newUser.Organization.ID, targetUser.ID.String())
-		if err != nil {
-			return nil, err
-		}
 	}
 
-	*user, err = u.userRepository.UpdateWithUuid(ctx, user.ID, user.AccountId, user.Name, newUser.Role.ID, user.Email,
-		user.Department, user.Description)
+	err = u.authRepository.UpdateExpiredTimeOnToken(ctx, user.Organization.ID, user.ID.String())
+
+	user.Roles = newUser.Roles
+	resp, err := u.userRepository.Update(ctx, user)
 	if err != nil {
 		return nil, errors.Wrap(err, "updating user in repository failed")
 	}
 
-	return user, nil
+	return resp, nil
 }
 
 func NewUserUsecase(r repository.Repository, kc keycloak.IKeycloak) IUserUsecase {

--- a/pkg/domain/admin/user.go
+++ b/pkg/domain/admin/user.go
@@ -7,13 +7,13 @@ import (
 )
 
 type CreateUserRequest struct {
-	AccountId     string `json:"accountId" validate:"required"`
-	Name          string `json:"name" validate:"name"`
-	Email         string `json:"email" validate:"required,email"`
-	Role          string `json:"role" validate:"required"`
-	Department    string `json:"department" validate:"min=0,max=50"`
-	Description   string `json:"description" validate:"min=0,max=100"`
-	AdminPassword string `json:"adminPassword"`
+	AccountId     string                    `json:"accountId" validate:"required"`
+	Name          string                    `json:"name" validate:"name"`
+	Email         string                    `json:"email" validate:"required,email"`
+	Roles         []domain.UserCreationRole `json:"roles" validate:"required"`
+	Department    string                    `json:"department" validate:"min=0,max=50"`
+	Description   string                    `json:"description" validate:"min=0,max=100"`
+	AdminPassword string                    `json:"adminPassword"`
 }
 
 type CreateUserResponse struct {
@@ -42,12 +42,12 @@ type GetUserResponse struct {
 }
 
 type UpdateUserRequest struct {
-	Name          string `json:"name" validate:"name"`
-	Email         string `json:"email" validate:"required,email"`
-	Department    string `json:"department" validate:"min=0,max=50"`
-	Role          string `json:"role" validate:"required"`
-	Description   string `json:"description" validate:"min=0,max=100"`
-	AdminPassword string `json:"adminPassword"`
+	Name          string                    `json:"name" validate:"name"`
+	Email         string                    `json:"email" validate:"required,email"`
+	Department    string                    `json:"department" validate:"min=0,max=50"`
+	Roles         []domain.UserCreationRole `json:"roles" validate:"required"`
+	Description   string                    `json:"description" validate:"min=0,max=100"`
+	AdminPassword string                    `json:"adminPassword"`
 }
 
 type UpdateUserResponse struct {

--- a/pkg/domain/admin/user.go
+++ b/pkg/domain/admin/user.go
@@ -30,7 +30,7 @@ type GetUserResponse struct {
 		ID           string                      `json:"id"`
 		AccountId    string                      `json:"accountId"`
 		Name         string                      `json:"name"`
-		Role         domain.RoleResponse         `json:"role"`
+		Roles        []domain.SimpleRoleResponse `json:"roles"`
 		Organization domain.OrganizationResponse `json:"organization"`
 		Email        string                      `json:"email"`
 		Department   string                      `json:"department"`
@@ -55,7 +55,7 @@ type UpdateUserResponse struct {
 		ID           string                      `json:"id"`
 		AccountId    string                      `json:"accountId"`
 		Name         string                      `json:"name"`
-		Role         domain.RoleResponse         `json:"role"`
+		Roles        []domain.SimpleRoleResponse `json:"roles"`
 		Organization domain.OrganizationResponse `json:"organization"`
 		Email        string                      `json:"email"`
 		Department   string                      `json:"department"`

--- a/pkg/domain/auth.go
+++ b/pkg/domain/auth.go
@@ -8,19 +8,14 @@ type LoginRequest struct {
 
 type LoginResponse struct {
 	User struct {
-		AccountId       string                 `json:"accountId"`
-		Name            string                 `json:"name"`
-		Token           string                 `json:"token"`
-		Role            RoleIdRoleNameResponse `json:"role"`
-		Department      string                 `json:"department"`
-		Organization    OrganizationResponse   `json:"organization"`
-		PasswordExpired bool                   `json:"passwordExpired"`
+		AccountId       string               `json:"accountId"`
+		Name            string               `json:"name"`
+		Token           string               `json:"token"`
+		Roles           []SimpleRoleResponse `json:"roles"`
+		Department      string               `json:"department"`
+		Organization    OrganizationResponse `json:"organization"`
+		PasswordExpired bool                 `json:"passwordExpired"`
 	} `json:"user"`
-}
-
-type RoleIdRoleNameResponse struct {
-	ID   string `json:"roleId"`
-	Name string `json:"roleName"`
 }
 
 type VerifyIdentityForLostIdRequest struct {

--- a/pkg/domain/role.go
+++ b/pkg/domain/role.go
@@ -27,10 +27,8 @@ type RoleResponse struct {
 }
 
 type SimpleRoleResponse = struct {
-	ID             string `json:"id"`
-	Name           string `json:"name"`
-	Description    string `json:"description"`
-	OrganizationID string `json:"organizationId"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type CreateTksRoleRequest struct {

--- a/pkg/domain/role.go
+++ b/pkg/domain/role.go
@@ -58,5 +58,10 @@ type ListTksRoleResponse struct {
 }
 
 type UpdateTksRoleRequest struct {
+	Name        string `json:"name" validate:"omitempty,min=0,max=100"`
 	Description string `json:"description" validate:"omitempty,min=0,max=100"`
+}
+
+type CheckRoleNameResponse struct {
+	IsExist bool `json:"isExist"`
 }

--- a/pkg/domain/role.go
+++ b/pkg/domain/role.go
@@ -63,3 +63,16 @@ type UpdateTksRoleRequest struct {
 type CheckRoleNameResponse struct {
 	IsExist bool `json:"isExist"`
 }
+
+type AppendUsersToRoleRequest struct {
+	Users []uuid.UUID `json:"users" validate:"required"`
+}
+
+type RemoveUsersFromRoleRequest struct {
+	Users []uuid.UUID `json:"users" validate:"required"`
+}
+
+type GetUsersInRoleIdResponse struct {
+	Users      []SimpleUserResponse `json:"users"`
+	Pagination PaginationResponse   `json:"pagination"`
+}

--- a/pkg/domain/user.go
+++ b/pkg/domain/user.go
@@ -30,7 +30,7 @@ type UserResponse struct {
 	Name              string    `json:"name"`
 	Token             string    `json:"token"`
 	RoleId            string
-	Role              RoleResponse `gorm:"foreignKey:RoleId;references:ID" json:"role"`
+	Roles             []RoleResponse `json:"roles"`
 	OrganizationId    string
 	Organization      OrganizationResponse `gorm:"foreignKey:OrganizationId;references:ID" json:"organization"`
 	Creator           string               `json:"creator"`
@@ -45,13 +45,17 @@ type UserResponse struct {
 }
 
 type CreateUserRequest struct {
-	AccountId   string `json:"accountId" validate:"required"`
-	Password    string `json:"password" validate:"required"`
-	Name        string `json:"name" validate:"name"`
-	Email       string `json:"email" validate:"required,email"`
-	Department  string `json:"department" validate:"min=0,max=50"`
-	Role        string `json:"role" validate:"required,oneof=admin user"`
-	Description string `json:"description" validate:"min=0,max=100"`
+	AccountId   string             `json:"accountId" validate:"required"`
+	Password    string             `json:"password" validate:"required"`
+	Name        string             `json:"name" validate:"name"`
+	Email       string             `json:"email" validate:"required,email"`
+	Department  string             `json:"department" validate:"min=0,max=50"`
+	Roles       []UserCreationRole `json:"roles" validate:"required"`
+	Description string             `json:"description" validate:"min=0,max=100"`
+}
+
+type UserCreationRole struct {
+	ID *string `json:"id" validate:"required"`
 }
 
 type SimpleUserResponse struct {
@@ -67,7 +71,7 @@ type CreateUserResponse struct {
 		ID           string               `json:"id"`
 		AccountId    string               `json:"accountId"`
 		Name         string               `json:"name"`
-		Role         RoleResponse         `json:"role"`
+		Roles        []SimpleRoleResponse `json:"roles"`
 		Organization OrganizationResponse `json:"organization"`
 		Email        string               `json:"email"`
 		Department   string               `json:"department"`
@@ -80,7 +84,7 @@ type GetUserResponse struct {
 		ID           string               `json:"id"`
 		AccountId    string               `json:"accountId"`
 		Name         string               `json:"name"`
-		Role         RoleResponse         `json:"role"`
+		Roles        []SimpleRoleResponse `json:"role"`
 		Organization OrganizationResponse `json:"organization"`
 		Email        string               `json:"email"`
 		Department   string               `json:"department"`
@@ -99,7 +103,7 @@ type ListUserBody struct {
 	ID           string               `json:"id"`
 	AccountId    string               `json:"accountId"`
 	Name         string               `json:"name"`
-	Role         RoleResponse         `json:"role"`
+	Roles        []SimpleRoleResponse `json:"roles"`
 	Organization OrganizationResponse `json:"organization"`
 	Email        string               `json:"email"`
 	Department   string               `json:"department"`
@@ -110,11 +114,11 @@ type ListUserBody struct {
 }
 
 type UpdateUserRequest struct {
-	Name        string `json:"name" validate:"omitempty,min=1,max=30"`
-	Role        string `json:"role" validate:"oneof=admin user"`
-	Email       string `json:"email" validate:"omitempty,email"`
-	Department  string `json:"department" validate:"omitempty,min=0,max=50"`
-	Description string `json:"description" validate:"omitempty,min=0,max=100"`
+	Name        string              `json:"name" validate:"required,min=1,max=30"`
+	Roles       *[]UserCreationRole `json:"roles" validate:"required"`
+	Email       string              `json:"email" validate:"required,email"`
+	Department  string              `json:"department" validate:"required,min=0,max=50"`
+	Description string              `json:"description" validate:"required,min=0,max=100"`
 }
 
 type UpdateUsersRequest struct {
@@ -133,7 +137,7 @@ type UpdateUserResponse struct {
 		ID           string               `json:"id"`
 		AccountId    string               `json:"accountId"`
 		Name         string               `json:"name"`
-		Role         RoleResponse         `json:"role"`
+		Roles        []SimpleRoleResponse `json:"roles"`
 		Organization OrganizationResponse `json:"organization"`
 		Email        string               `json:"email"`
 		Department   string               `json:"department"`
@@ -148,7 +152,7 @@ type GetMyProfileResponse struct {
 		ID           string               `json:"id"`
 		AccountId    string               `json:"accountId"`
 		Name         string               `json:"name"`
-		Role         RoleResponse         `json:"role"`
+		Roles        []RoleResponse       `json:"roles"`
 		Organization OrganizationResponse `json:"organization"`
 		Email        string               `json:"email"`
 		Department   string               `json:"department"`
@@ -156,9 +160,9 @@ type GetMyProfileResponse struct {
 }
 type UpdateMyProfileRequest struct {
 	Password   string `json:"password" validate:"required"`
-	Name       string `json:"name" validate:"omitempty,min=1,max=30"`
-	Email      string `json:"email" validate:"omitempty,email"`
-	Department string `json:"department" validate:"omitempty,min=0,max=50"`
+	Name       string `json:"name" validate:"required,min=1,max=30"`
+	Email      string `json:"email" validate:"required,email"`
+	Department string `json:"department" validate:"required,min=0,max=50"`
 }
 
 type UpdateMyProfileResponse struct {
@@ -166,7 +170,7 @@ type UpdateMyProfileResponse struct {
 		ID           string               `json:"id"`
 		AccountId    string               `json:"accountId"`
 		Name         string               `json:"name"`
-		Role         RoleResponse         `json:"role"`
+		Roles        []SimpleRoleResponse `json:"role"`
 		Organization OrganizationResponse `json:"organization"`
 		Email        string               `json:"email"`
 		Department   string               `json:"department"`

--- a/pkg/domain/user.go
+++ b/pkg/domain/user.go
@@ -114,7 +114,7 @@ type ListUserBody struct {
 }
 
 type UpdateUserRequest struct {
-	Name        string             `json:"name" validate:"required""`
+	Name        string             `json:"name" validate:"required"`
 	Roles       []UserCreationRole `json:"roles" validate:"required"`
 	Email       string             `json:"email" validate:"required,email"`
 	Department  string             `json:"department" validate:"min=0,max=50"`

--- a/pkg/domain/user.go
+++ b/pkg/domain/user.go
@@ -30,7 +30,7 @@ type UserResponse struct {
 	Name              string    `json:"name"`
 	Token             string    `json:"token"`
 	RoleId            string
-	Roles             []RoleResponse `json:"roles"`
+	Roles             []SimpleRoleResponse `json:"roles"`
 	OrganizationId    string
 	Organization      OrganizationResponse `gorm:"foreignKey:OrganizationId;references:ID" json:"organization"`
 	Creator           string               `json:"creator"`
@@ -114,21 +114,21 @@ type ListUserBody struct {
 }
 
 type UpdateUserRequest struct {
-	Name        string              `json:"name" validate:"required,min=1,max=30"`
-	Roles       *[]UserCreationRole `json:"roles" validate:"required"`
-	Email       string              `json:"email" validate:"required,email"`
-	Department  string              `json:"department" validate:"required,min=0,max=50"`
-	Description string              `json:"description" validate:"required,min=0,max=100"`
+	Name        string             `json:"name" validate:"required""`
+	Roles       []UserCreationRole `json:"roles" validate:"required"`
+	Email       string             `json:"email" validate:"required,email"`
+	Department  string             `json:"department" validate:"min=0,max=50"`
+	Description string             `json:"description" validate:"min=0,max=100"`
 }
 
 type UpdateUsersRequest struct {
 	Users []struct {
-		AccountId   string `json:"accountId" validate:"required"`
-		Name        string `json:"name" validate:"omitempty,min=1,max=30"`
-		Role        string `json:"role" validate:"oneof=admin user"`
-		Email       string `json:"email" validate:"omitempty,email"`
-		Department  string `json:"department" validate:"omitempty,min=0,max=50"`
-		Description string `json:"description" validate:"omitempty,min=0,max=100"`
+		AccountId   string             `json:"accountId" validate:"required"`
+		Name        string             `json:"name" validate:"required,name"`
+		Roles       []UserCreationRole `json:"roles" validate:"required"`
+		Email       string             `json:"email" validate:"required,email"`
+		Department  string             `json:"department" validate:"min=0,max=50"`
+		Description string             `json:"description" validate:"min=0,max=100"`
 	} `json:"users"`
 }
 
@@ -152,7 +152,7 @@ type GetMyProfileResponse struct {
 		ID           string               `json:"id"`
 		AccountId    string               `json:"accountId"`
 		Name         string               `json:"name"`
-		Roles        []RoleResponse       `json:"roles"`
+		Roles        []SimpleRoleResponse `json:"roles"`
 		Organization OrganizationResponse `json:"organization"`
 		Email        string               `json:"email"`
 		Department   string               `json:"department"`

--- a/pkg/domain/user.go
+++ b/pkg/domain/user.go
@@ -6,23 +6,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// // Deprecated: Policy is deprecated, use Permission instead.
-//
-//	type Policy = struct {
-//		ID               string    `json:"id"`
-//		Name             string    `json:"name"`
-//		Create           bool      `json:"create"`
-//		CreatePriviledge string    `json:"createPriviledge"`
-//		Update           bool      `json:"update"`
-//		UpdatePriviledge string    `json:"updatePriviledge"`
-//		Read             bool      `json:"read"`
-//		ReadPriviledge   string    `json:"readPriviledge"`
-//		Delete           bool      `json:"delete"`
-//		DeletePriviledge string    `json:"deletePriviledge"`
-//		Creator          string    `json:"creator"`
-//		CreatedAt        time.Time `json:"createdAt"`
-//		UpdatedAt        time.Time `json:"updatedAt"`
-//	}
 type UserResponse struct {
 	ID                uuid.UUID `gorm:"primarykey;type:uuid" json:"id"`
 	AccountId         string    `json:"accountId"`

--- a/pkg/domain/user.go
+++ b/pkg/domain/user.go
@@ -117,6 +117,17 @@ type UpdateUserRequest struct {
 	Description string `json:"description" validate:"omitempty,min=0,max=100"`
 }
 
+type UpdateUsersRequest struct {
+	Users []struct {
+		AccountId   string `json:"accountId" validate:"required"`
+		Name        string `json:"name" validate:"omitempty,min=1,max=30"`
+		Role        string `json:"role" validate:"oneof=admin user"`
+		Email       string `json:"email" validate:"omitempty,email"`
+		Department  string `json:"department" validate:"omitempty,min=0,max=50"`
+		Description string `json:"description" validate:"omitempty,min=0,max=100"`
+	} `json:"users"`
+}
+
 type UpdateUserResponse struct {
 	User struct {
 		ID           string               `json:"id"`


### PR DESCRIPTION
"User" 구조체 내부 단수 Role -> 복수 Roles 를 가질 수 있도록 개편되었습니다. "User" 구조체를 사용하는 FrontEnd, CLI 모두 해당 부분에 대한 반영이 필요합니다.

@Siyeop 시엽님, 해당 변경으로 인해 FrontEnd쪽에서 빠르게 반영해야하는 이슈가 있는지 한번 확인 부탁드립니다.
대표적으로 영향 받는 API는 Login과 User Read API(Get List) 들이 있습니다.

**Login 기존 응답 형식**
```json
    "user": {
        "accountId": "admin",
        ...
        "role": {
            "roleId": "23618210-81c7-4b8f-89ea-764b8bf96fd5",
            "roleName": "user"
        },
        ...
```
**Login 변경된 응답 형식**
```json
{
    "user": {
        "accountId": "admin",
        ...
        "roles": [
            {
                "id": "9a9f9da7-40ef-46cc-9dc6-70ad7eb70e92",
                "name": "admin"
            },
            {
                "id": "23618210-81c7-4b8f-89ea-764b8bf96fd5",
                "name": "user"
            }
        ],
        ...
```

**List User 기존 응답 형식**
```json
{
    "users": [
        {
            "id": "a4cee97c-943d-44df-92a1-a770c30eed5f",
            ...
            "role": {
                "id": "23618210-81c7-4b8f-89ea-764b8bf96fd5",
                "name": "user",
                ...
                },
            ...
        },
```
**List User 변경된 응답 형식**
```json
{
    "users": [
        {
            "id": "a4cee97c-943d-44df-92a1-a770c30eed5f",
            ...
            "roles": [
                {
                    "id": "9a9f9da7-40ef-46cc-9dc6-70ad7eb70e92",
                    "name": "admin"
                },
                {
                    "id": "23618210-81c7-4b8f-89ea-764b8bf96fd5",
                    "name": "user"
                }
            ],
            ...
        },
```