### PR TITLE
정책 조회시 대상 클러스터 이름도 표시

### DIFF
--- a/internal/delivery/http/policy.go
+++ b/internal/delivery/http/policy.go
@@ -318,6 +318,14 @@ func (h *PolicyHandler) GetPolicy(w http.ResponseWriter, r *http.Request) {
 		log.Error(r.Context(), err)
 	}
 
+	out.Policy.TargetClusters = make([]domain.SimpleClusterResponse, len(policy.TargetClusters))
+
+	for i, targetCluster := range policy.TargetClusters {
+		if err = serializer.Map(r.Context(), targetCluster, &out.Policy.TargetClusters[i]); err != nil {
+			log.Error(r.Context(), err)
+		}
+	}
+
 	ResponseJSON(w, r, http.StatusOK, out)
 }
 
@@ -362,6 +370,14 @@ func (h *PolicyHandler) ListPolicy(w http.ResponseWriter, r *http.Request) {
 		if err := serializer.Map(r.Context(), policy, &out.Policies[i]); err != nil {
 			log.Info(r.Context(), err)
 			continue
+		}
+
+		out.Policies[i].TargetClusters = make([]domain.SimpleClusterResponse, len(policy.TargetClusters))
+
+		for j, targetCluster := range policy.TargetClusters {
+			if err = serializer.Map(r.Context(), targetCluster, &out.Policies[i].TargetClusters[j]); err != nil {
+				log.Error(r.Context(), err)
+			}
 		}
 	}
 
@@ -791,6 +807,14 @@ func (h *PolicyHandler) GetPolicyEdit(w http.ResponseWriter, r *http.Request) {
 	var out domain.GetPolicyResponse
 	if err = serializer.Map(r.Context(), *policy, &out.Policy); err != nil {
 		log.Error(r.Context(), err)
+	}
+
+	out.Policy.TargetClusters = make([]domain.SimpleClusterResponse, len(policy.TargetClusters))
+
+	for i, targetCluster := range policy.TargetClusters {
+		if err = serializer.Map(r.Context(), targetCluster, &out.Policy.TargetClusters[i]); err != nil {
+			log.Error(r.Context(), err)
+		}
 	}
 
 	parameterSchema := policy.PolicyTemplate.ParametersSchema

--- a/pkg/domain/policy.go
+++ b/pkg/domain/policy.go
@@ -33,8 +33,9 @@ type PolicyResponse struct {
 	CreatedAt time.Time          `json:"createdAt" format:"date-time"`
 	UpdatedAt time.Time          `json:"updatedAt" format:"date-time"`
 
-	TargetClusterIds []string `json:"targetClusterIds" example:"83bf8081-f0c5-4b31-826d-23f6f366ec90,83bf8081-f0c5-4b31-826d-23f6f366ec90"`
-	Mandatory        bool     `json:"mandatory"`
+	//	TargetClusterIds []string                `json:"targetClusterIds" example:"83bf8081-f0c5-4b31-826d-23f6f366ec90,83bf8081-f0c5-4b31-826d-23f6f366ec90"`
+	TargetClusters []SimpleClusterResponse `json:"targetClusters"`
+	Mandatory      bool                    `json:"mandatory"`
 
 	PolicyName         string          `json:"policyName" example:"label 정책"`
 	PolicyResourceName string          `json:"policyResourceName,omitempty" example:"labelpolicy"`


### PR DESCRIPTION
Before
"targetClusterIds": ["co-op2-1"]

After

"targetClusters": [
      {
        "id": "co-op2-1",
        "organizationId": "ozvnzr3oz",
        "name": "policy-test1"
      }
 ],