### PR TITLE
bugfix. Fix internal k8s API call with admin token

### DIFF
--- a/internal/usecase/project.go
+++ b/internal/usecase/project.go
@@ -531,7 +531,7 @@ func (u *ProjectUsecase) MayRemoveRequiredSetupForCluster(ctx context.Context, o
 	return nil
 }
 func (u *ProjectUsecase) createK8SInitialResource(ctx context.Context, organizationId string, projectId string, stackId string) error {
-	kubeconfig, err := kubernetes.GetKubeConfig(ctx, stackId)
+	kubeconfig, err := kubernetes.GetKubeConfig(ctx, stackId, kubernetes.KubeconfigForAdmin)
 	if err != nil {
 		log.Error(ctx, err)
 		return errors.Wrap(err, "Failed to create project namespace.")
@@ -564,7 +564,7 @@ func (u *ProjectUsecase) createK8SInitialResource(ctx context.Context, organizat
 	return nil
 }
 func (u *ProjectUsecase) deleteK8SInitialResource(ctx context.Context, organizationId string, projectId string, stackId string) error {
-	kubeconfig, err := kubernetes.GetKubeConfig(ctx, stackId)
+	kubeconfig, err := kubernetes.GetKubeConfig(ctx, stackId, kubernetes.KubeconfigForAdmin)
 	if err != nil {
 		log.Error(ctx, err)
 		return errors.Wrap(err, "Failed to create project namespace.")
@@ -622,7 +622,7 @@ func (u *ProjectUsecase) deleteKeycloakClientRoles(ctx context.Context, organiza
 	return nil
 }
 func (u *ProjectUsecase) CreateK8SNSRoleBinding(ctx context.Context, organizationId string, projectId string, stackId string, namespace string) error {
-	kubeconfig, err := kubernetes.GetKubeConfig(ctx, stackId)
+	kubeconfig, err := kubernetes.GetKubeConfig(ctx, stackId, kubernetes.KubeconfigForAdmin)
 	if err != nil {
 		log.Error(ctx, err)
 		return errors.Wrap(err, "Failed to create project namespace.")
@@ -724,7 +724,7 @@ func (u *ProjectUsecase) GetProjectKubeconfig(ctx context.Context, organizationI
 
 	kubeconfigs := make([]string, 0)
 	for _, pn := range projectNamespaces {
-		kubeconfig, err := kubernetes.GetKubeConfig(ctx, pn.StackId)
+		kubeconfig, err := kubernetes.GetKubeConfig(ctx, pn.StackId, kubernetes.KubeconfigForUser)
 		if err != nil {
 			log.Error(ctx, err)
 			return "", errors.Wrap(err, "Failed to retrieve kubeconfig.")

--- a/internal/usecase/stack.go
+++ b/internal/usecase/stack.go
@@ -482,7 +482,7 @@ func (u *StackUsecase) Delete(ctx context.Context, dto model.Stack) (err error) 
 }
 
 func (u *StackUsecase) GetKubeConfig(ctx context.Context, stackId domain.StackId) (kubeConfig string, err error) {
-	kubeconfig, err := kubernetes.GetKubeConfig(ctx, stackId.String())
+	kubeconfig, err := kubernetes.GetKubeConfig(ctx, stackId.String(), kubernetes.KubeconfigForUser)
 	//kubeconfig, err := kubernetes.GetKubeConfig("cmsai5k5l")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Project의 NS 생성 시, 해당 cluster에 controlplane용 kubeconfig를 사용해야 함.
기존의 GetKubeconfig()는 user kubeconfig를 돌려주는 함수였으나 이를 controlplane 또는 user 둘 중에 선택할 수 있도록 수정