### PR TITLE
bugfix. fix bugs on connection to remote cluster with kubeconfig

### DIFF
--- a/internal/delivery/http/project.go
+++ b/internal/delivery/http/project.go
@@ -1310,6 +1310,12 @@ func (p ProjectHandler) CreateProjectNamespace(w http.ResponseWriter, r *http.Re
 	}
 
 	// tasks for keycloak & k8s
+	// ToDo: Check if the namespace is already created
+	if err := p.usecase.EnsureNamespaceForCluster(r.Context(), organizationId, projectNamespaceReq.StackId, projectNamespaceReq.Namespace); err != nil {
+		ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
+		return
+	}
+
 	if err := p.usecase.EnsureRequiredSetupForCluster(r.Context(), organizationId, projectId, projectNamespaceReq.StackId); err != nil {
 		ErrorJSON(w, r, httpErrors.NewInternalServerError(err, "", ""))
 		return

--- a/internal/keycloak/keycloak.go
+++ b/internal/keycloak/keycloak.go
@@ -484,10 +484,18 @@ func (k *Keycloak) EnsureClientRoleWithClientName(ctx context.Context, organizat
 		Name: gocloak.StringP(roleName),
 	}
 
-	_, err = k.client.CreateClientRole(context.Background(), token.AccessToken, organizationId, *targetClient.ID, role)
+	r, err := k.client.GetClientRole(context.Background(), token.AccessToken, organizationId, *targetClient.ID, roleName)
 	if err != nil {
-		log.Error(ctx, "Creating Client Role is failed", err)
+		log.Error(ctx, "Getting Client Role is failed", err)
 		return err
+	}
+
+	if r == nil {
+		_, err = k.client.CreateClientRole(context.Background(), token.AccessToken, organizationId, *targetClient.ID, role)
+		if err != nil {
+			log.Error(ctx, "Creating Client Role is failed", err)
+			return err
+		}
 	}
 
 	return nil
@@ -519,10 +527,18 @@ func (k *Keycloak) DeleteClientRoleWithClientName(ctx context.Context, organizat
 		return nil
 	}
 
-	err = k.client.DeleteClientRole(context.Background(), token.AccessToken, organizationId, *targetClient.ID, *roles[0].ID)
+	r, err := k.client.GetClientRole(context.Background(), token.AccessToken, organizationId, *targetClient.ID, roleName)
 	if err != nil {
-		log.Error(ctx, "Deleting Client Role is failed", err)
+		log.Error(ctx, "Getting Client Role is failed", err)
 		return err
+	}
+
+	if r != nil {
+		err = k.client.DeleteClientRole(context.Background(), token.AccessToken, organizationId, *targetClient.ID, *roles[0].ID)
+		if err != nil {
+			log.Error(ctx, "Deleting Client Role is failed", err)
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Project NS 생성 시, 해당 stack에 자원을 생성하는 로직 일부 수정.
- (기존)Project Name -> (변경)Project Id
- K8s & Keycloak에 대해 생성 API가 여러번 호출 되어도 문제가 없도록 수정