### PR TITLE
Template CR 생성 시 포맷팅 개선

### DIFF
--- a/internal/policy-template/policy-template-rego.go
+++ b/internal/policy-template/policy-template-rego.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/format"
 	"github.com/open-policy-agent/opa/types"
 	"github.com/openinfradev/tks-api/internal/model"
 	"github.com/openinfradev/tks-api/pkg/domain"
@@ -557,4 +558,33 @@ func GetPackageFromRegoCode(regoCode string) string {
 	}
 
 	return ""
+}
+
+func FormatRegoCode(rego string) string {
+	packageName := GetPackageFromRegoCode(rego)
+
+	// 패키지 명을 파싱할 수 없으면 포맷팅할 수 있는 코드가 아닐 것이므로 그냥 리턴
+	if packageName == "" {
+		return rego
+	}
+
+	bytes, err := format.Source("rego", []byte(rego))
+
+	if err != nil {
+		return rego
+	}
+
+	return strings.Replace(string(bytes), "\t", "  ", -1)
+}
+
+func FormatLibCode(libs []string) []string {
+	processedLibs := processLibs(libs)
+
+	result := make([]string, len(processedLibs))
+
+	for i, lib := range processedLibs {
+		result[i] = FormatRegoCode(lib)
+	}
+
+	return result
 }

--- a/internal/policy-template/tkspolicytemplate.go
+++ b/internal/policy-template/tkspolicytemplate.go
@@ -47,8 +47,8 @@ type Validation struct {
 
 type Target struct {
 	Target string   `json:"target,omitempty"`
-	Rego   string   `json:"rego,omitempty" yaml:"rego,omitempty,flow"`
-	Libs   []string `json:"libs,omitempty" yaml:"libs,omitempty,flow"`
+	Rego   string   `json:"rego,omitempty" yaml:"rego,omitempty"`
+	Libs   []string `json:"libs,omitempty" yaml:"libs,omitempty"`
 	Code   []Code   `json:"code,omitempty"`
 }
 

--- a/internal/usecase/policy-template.go
+++ b/internal/usecase/policy-template.go
@@ -117,6 +117,9 @@ func (u *PolicyTemplateUsecase) Create(ctx context.Context, dto model.PolicyTemp
 	userId := user.GetUserId()
 	dto.CreatorId = &userId
 
+	dto.Rego = policytemplate.FormatRegoCode(dto.Rego)
+	dto.Libs = policytemplate.FormatLibCode(dto.Libs)
+
 	id, err := u.repo.Create(ctx, dto)
 
 	if err != nil {
@@ -477,6 +480,9 @@ func (u *PolicyTemplateUsecase) CreatePolicyTemplateVersion(ctx context.Context,
 	if err := policytemplate.ValidateParamDefs(policyTemplate.ParametersSchema); err != nil {
 		return "", httpErrors.NewBadRequestError(err, "PT_INVALID_PARAMETER_SCHEMA", "")
 	}
+
+	rego = policytemplate.FormatRegoCode(rego)
+	libs = policytemplate.FormatLibCode(libs)
 
 	return u.repo.CreatePolicyTemplateVersion(ctx, policyTemplateId, newVersion, schema, rego, libs)
 }


### PR DESCRIPTION
Policy Template CR 포맷팅 개선
- OPA formatter 적용
- 탭을 공백 두개로 치환