### PR TITLE
Gatekeeper 템플릿 스키마에 addtionalProperties가 추가되어 전달되는 버그 수정

### DIFF
--- a/internal/policy-template/policy-operator.go
+++ b/internal/policy-template/policy-operator.go
@@ -104,7 +104,7 @@ func PolicyTemplateToTksPolicyTemplateCR(policyTemplate *model.PolicyTemplate) *
 						Kind: policyTemplate.Kind,
 					},
 					Validation: &Validation{
-						OpenAPIV3Schema: ParamDefsToJSONSchemaProeprties(policyTemplate.ParametersSchema),
+						OpenAPIV3Schema: ParamDefsToJSONSchemaProeprties(policyTemplate.ParametersSchema, false),
 					},
 				},
 			},

--- a/internal/policy-template/validation.go
+++ b/internal/policy-template/validation.go
@@ -47,7 +47,7 @@ func ValidateParamDefs(paramdefs []*domain.ParameterDef) error {
 }
 
 func ValidateJSONusingParamdefs(paramdefs []*domain.ParameterDef, jsonStr string) error {
-	jsonSchema := ParamDefsToJSONSchemaProeprties(paramdefs)
+	jsonSchema := ParamDefsToJSONSchemaProeprties(paramdefs, true)
 
 	if jsonSchema == nil {
 		// 파라미터가 없는데 "{}" 이나 ""이면 에러가 아님


### PR DESCRIPTION
- Gatekeeper 템플릿 스키마에 addtionalProperties가 추가되어 전달되는 버그 수정
- addtionalProperties는 JSON Schema Validation 시에만 사용해야 함