### PR TITLE
trivial. update status when snr deleting

### DIFF
--- a/internal/usecase/system-notification-rule.go
+++ b/internal/usecase/system-notification-rule.go
@@ -158,6 +158,12 @@ func (u *SystemNotificationRuleUsecase) Delete(ctx context.Context, systemNotifi
 	if err != nil {
 		return err
 	}
+
+	// update status for appling kubernetes
+	if err = u.repo.UpdateStatus(ctx, systemNotificationRuleId, domain.SystemNotificationRuleStatus_PENDING); err != nil {
+		return err
+	}
+
 	return
 }
 


### PR DESCRIPTION
시스템 알림 설정 삭제시 kubernetes 에 적용하기 위하여 status 를 pending 상태로 변경합니다.