### PR TITLE
bugfix: relate task with parent app on create job

### DIFF
--- a/internal/repository/app-serve-app.go
+++ b/internal/repository/app-serve-app.go
@@ -26,7 +26,7 @@ type IAppServeAppRepository interface {
 
 	IsAppServeAppExist(ctx context.Context, appId string) (int64, error)
 	IsAppServeAppNameExist(ctx context.Context, orgId string, appName string) (int64, error)
-	CreateTask(ctx context.Context, task *model.AppServeAppTask) (taskId string, err error)
+	CreateTask(ctx context.Context, task *model.AppServeAppTask, appId string) (taskId string, err error)
 	UpdateStatus(ctx context.Context, appId string, taskId string, status string, output string) error
 	UpdateEndpoint(ctx context.Context, appId string, taskId string, endpoint string, previewEndpoint string, helmRevision int32) error
 	GetTaskCountById(ctx context.Context, appId string) (int64, error)
@@ -53,8 +53,11 @@ func (r *AppServeAppRepository) CreateAppServeApp(ctx context.Context, app *mode
 }
 
 // Update creates new appServeApp task for existing appServeApp.
-func (r *AppServeAppRepository) CreateTask(ctx context.Context, task *model.AppServeAppTask) (string, error) {
+func (r *AppServeAppRepository) CreateTask(ctx context.Context, task *model.AppServeAppTask, appId string) (string, error) {
 	task.ID = uuid.New().String()
+    if len(appId) > 0 {
+        task.AppServeAppId = appId
+    }
 	res := r.db.WithContext(ctx).Create(task)
 	if res.Error != nil {
 		return "", res.Error

--- a/internal/usecase/app-serve-app.go
+++ b/internal/usecase/app-serve-app.go
@@ -131,7 +131,7 @@ func (u *AppServeAppUsecase) CreateAppServeApp(ctx context.Context, app *model.A
 		return "", "", errors.Wrap(err, "Failed to create app.")
 	}
 
-	taskId, err := u.repo.CreateTask(ctx, task)
+	taskId, err := u.repo.CreateTask(ctx, task, appId)
 	if err != nil {
 		log.Error(ctx, err)
 		return "", "", errors.Wrap(err, "Failed to create task.")
@@ -395,7 +395,7 @@ func (u *AppServeAppUsecase) DeleteAppServeApp(ctx context.Context, appId string
 		CreatedAt:     time.Now(),
 	}
 
-	taskId, err := u.repo.CreateTask(ctx, appTask)
+	taskId, err := u.repo.CreateTask(ctx, appTask, "")
 	if err != nil {
 		log.Error(ctx, "taskId = ", taskId)
 		log.Error(ctx, "Failed to create delete task. Err:", err)
@@ -503,7 +503,8 @@ func (u *AppServeAppUsecase) UpdateAppServeApp(ctx context.Context, appId string
 		log.Debug(ctx, "After transform, extraEnv: ", extEnv)
 	}
 
-	taskId, err := u.repo.CreateTask(ctx, appTask)
+    // TODO: Check if appId is necessary here.
+	taskId, err := u.repo.CreateTask(ctx, appTask, appId)
 	if err != nil {
 		log.Info(ctx, "taskId = ", taskId)
 		return "", fmt.Errorf("failed to update app-serve application. Err: %s", err)
@@ -728,7 +729,7 @@ func (u *AppServeAppUsecase) RollbackAppServeApp(ctx context.Context, appId stri
 	task.RollbackVersion = targetVer
 
 	// Creates new task record from the target task
-	newTaskId, err := u.repo.CreateTask(ctx, task)
+	newTaskId, err := u.repo.CreateTask(ctx, task, "")
 	if err != nil {
 		log.Info(ctx, "taskId = ", newTaskId)
 		return "", fmt.Errorf("failed to rollback app-serve application. Err: %s", err)


### PR DESCRIPTION
앱서빙 리팩토링 시의 db 스키마 변경으로 인해 app과 task 테이블 간의 foreign key 연결이 없어지면서, 두 테이블 간의 관계를 수동으로 처리해주도록 수정함.
