### PR TITLE
Policy Get에서 NotFound 에러를 별도 처리하지 않도록 수정

### DIFF
--- a/internal/repository/policy.go
+++ b/internal/repository/policy.go
@@ -184,13 +184,8 @@ func (r *PolicyRepository) GetBy(ctx context.Context, organizationId string, key
 	res := r.db.WithContext(ctx).Preload(clause.Associations).
 		Where(query, organizationId, value).First(&policy)
 	if res.Error != nil {
-		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
-			log.Infof(ctx, "Not found policy %s='%v'", key, value)
-			return nil, nil
-		} else {
-			log.Error(ctx, res.Error)
-			return nil, res.Error
-		}
+		log.Error(ctx, res.Error)
+		return nil, res.Error
 	}
 
 	return &policy, nil


### PR DESCRIPTION
Policy Get에서 NotFound 에러를 별도 처리하지 않도록 수정