### PR TITLE
trivial. resize tks-api logs

### DIFF
--- a/internal/middleware/logging/logging.go
+++ b/internal/middleware/logging/logging.go
@@ -12,6 +12,8 @@ import (
 	"github.com/openinfradev/tks-api/pkg/log"
 )
 
+const MAX_LOG_LEN = 1000
+
 func LoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -29,7 +31,8 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(lrw, r)
 
 		statusCode := lrw.GetStatusCode()
-		log.Infof(r.Context(), "[API_RESPONSE] [%d][%s][%s]", statusCode, http.StatusText(statusCode), lrw.GetBody().String())
+
+		log.Infof(r.Context(), "[API_RESPONSE] [%d][%s][%s]", statusCode, http.StatusText(statusCode), lrw.GetBody().String()[:MAX_LOG_LEN-1])
 		log.Infof(r.Context(), "***** END [%s %s] *****", r.Method, r.RequestURI)
 	})
 }

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -81,7 +81,7 @@ func recursiveMap(ctx context.Context, src interface{}, dst interface{}, convert
 						dstField.Set(reflect.ValueOf(converted))
 					}
 				} else {
-					log.Debugf(ctx, "no converter found for %s -> %s", srcField.Type(), dstField.Type())
+					//log.Debugf(ctx, "no converter found for %s -> %s", srcField.Type(), dstField.Type())
 					continue
 				}
 			}


### PR DESCRIPTION
로그 사이즈를 최대 한줄에 최대 1000 으로 줄입니다.
상용시 로그 정책에 대해서는 추후 고민합니다.