### PR TITLE
policy match kind: nil derefence error fix

### DIFF
--- a/internal/delivery/http/policy.go
+++ b/internal/delivery/http/policy.go
@@ -99,7 +99,7 @@ func (h *PolicyHandler) CreatePolicy(w http.ResponseWriter, r *http.Request) {
 			ErrorJSON(w, r, err)
 			return
 		}
-	} else {
+	} else if input.Match != nil {
 		normaized, err := policytemplate.CheckAndNormalizeKinds(input.Match.Kinds)
 
 		if err != nil {
@@ -200,7 +200,7 @@ func (h *PolicyHandler) UpdatePolicy(w http.ResponseWriter, r *http.Request) {
 			ErrorJSON(w, r, err)
 			return
 		}
-	} else {
+	} else if input.Match != nil {
 		normaized, err := policytemplate.CheckAndNormalizeKinds(input.Match.Kinds)
 		if err != nil {
 			ErrorJSON(w, r, httpErrors.NewBadRequestError(fmt.Errorf("match error: %s", err), "P_INVALID_MATCH", ""))


### PR DESCRIPTION
정책 생성 시 match 절의 kinds 목록에 apiGroup을 채워주는 기능 추가 후 부터 발생하는 match가 nil인 경우 nil dereference 가 발생하는 버그 수정 