### PR TITLE
bugfix: return availableRollback value by GetTasks API

### DIFF
--- a/internal/delivery/http/app-serve-app.go
+++ b/internal/delivery/http/app-serve-app.go
@@ -481,6 +481,12 @@ func (h *AppServeAppHandler) GetAppServeAppTasksByAppId(w http.ResponseWriter, r
 	var out domain.GetAppServeAppTasksResponse
 	out.AppServeAppTasks = make([]domain.AppServeAppTaskResponse, len(tasks))
 	for i, task := range tasks {
+		// Rollbacking to latest task should be blocked.
+		if i > 0 && strings.Contains(task.Status, "SUCCESS") && task.Status != "ABORT_SUCCESS" &&
+			task.Status != "ROLLBACK_SUCCESS" {
+			task.AvailableRollback = true
+		}
+
 		if err := serializer.Map(r.Context(), task, &out.AppServeAppTasks[i]); err != nil {
 			log.Info(r.Context(), err)
 			continue


### PR DESCRIPTION
rollback 가능 여부를 판단하게 해주는 값을 개별 task 뿐 아니라 GetTasks API에서도 리턴하도록 수정