### PR TITLE
gorm DB 관계 업데이트 시 제외 처리가 안 되어 중복 레코드 삽입시도되는 버그 수정

### DIFF
--- a/internal/repository/policy-template.go
+++ b/internal/repository/policy-template.go
@@ -88,7 +88,7 @@ func (r *PolicyTemplateRepository) Update(ctx context.Context, policyTemplateId 
 		}
 
 		if len(updateMap) > 0 {
-			err = tx.WithContext(ctx).Model(&policyTemplate).Limit(1).
+			err = tx.WithContext(ctx).Omit("PermittedOrganizations").Model(&policyTemplate).Limit(1).
 				Where("id = ?", policyTemplateId).Where("type = ?", "tks").
 				Updates(updateMap).Error
 

--- a/internal/repository/policy.go
+++ b/internal/repository/policy.go
@@ -87,7 +87,7 @@ func (r *PolicyRepository) Update(ctx context.Context, organizationId string, po
 		}
 
 		if len(updateMap) > 0 {
-			err = tx.WithContext(ctx).Model(&policy).Limit(1).
+			err = tx.WithContext(ctx).Omit("TargetClusters").Model(&policy).Limit(1).
 				Where("id = ?", policyId).
 				Updates(updateMap).Error
 


### PR DESCRIPTION
gorm 관계 테이블 업데이트 시 Omit 처리를 하지 않으면 관계 테이블 참조하고 있는 전체 값에 대한 추가 시도로 duplicate key 에러가 발생할 수 있어 이를 수정