### PR TITLE
feature. implementation calculating resources for namespace

### DIFF
--- a/internal/delivery/http/app-serve-app.go
+++ b/internal/delivery/http/app-serve-app.go
@@ -113,7 +113,7 @@ func (h *AppServeAppHandler) CreateAppServeApp(w http.ResponseWriter, r *http.Re
 	appReq := domain.CreateAppServeAppRequest{}
 	err := UnmarshalRequestInput(r, &appReq)
 	if err != nil {
-		ErrorJSON(w, r, httpErrors.NewBadRequestError(fmt.Errorf("Error while unmarshalling request"), "C_INTERNAL_ERROR", ""))
+		ErrorJSON(w, r, err)
 		return
 	}
 

--- a/internal/usecase/dashboard.go
+++ b/internal/usecase/dashboard.go
@@ -1141,6 +1141,11 @@ func (u *DashboardUsecase) GetThanosClient(ctx context.Context, organizationId s
 		return nil, httpErrors.NewInternalServerError(err, "D_INVALID_PRIMARY_STACK", "")
 	}
 	address, port := helper.SplitAddress(ctx, thanosUrl)
+
+	// [TEST]
+	//address = "http://a93c60de70c794ef39b495976588c989-d7cd29ca75def693.elb.ap-northeast-2.amazonaws.com"
+	//port = 9090
+
 	client, err := thanos.New(address, port, false, "")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create thanos client")

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"context"
 	"regexp"
 	"strings"
 	"unicode/utf8"
@@ -10,7 +11,7 @@ import (
 	validator "github.com/go-playground/validator/v10"
 	en_translations "github.com/go-playground/validator/v10/translations/en"
 	"github.com/openinfradev/tks-api/pkg/domain"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/openinfradev/tks-api/pkg/log"
 )
 
 const (
@@ -30,7 +31,7 @@ func NewValidator() (*validator.Validate, *ut.UniversalTranslator) {
 	v := validator.New()
 	err := en_translations.RegisterDefaultTranslations(v, trans)
 	if err != nil {
-		log.Error(err)
+		log.Error(context.TODO(), err)
 	}
 
 	// register custom validator

--- a/pkg/thanos-client/types.go
+++ b/pkg/thanos-client/types.go
@@ -18,6 +18,7 @@ type MetricDataResult struct {
 
 type MetricDataResultMetric struct {
 	Name        string `json:"__name__"`
+	Namespace   string `json:"namespace,omitempty"`
 	TacoCluster string `json:"taco_cluster"`
 }
 


### PR DESCRIPTION
namespace 의 자원 사용량을 위한 API 를 구현합니다.
 . cpu : sum(rate(container_cpu_usage_seconds_total{image!=\"\", namespace=\"%s\"}[10m]) ) by (taco_cluster, namespace)
 . sum(container_memory_working_set_bytes{image!=\"\", namespace=\"%s\"}) by (taco_cluster, namespace)

테스트를 위해 선 merge 하며, 쿼리문에 대한 리뷰는 따로 컨펌받습니다.