### PR TITLE
temp-fix: make appserving dashboard not being refreshed for now

### DIFF
--- a/internal/usecase/app-serve-app.go
+++ b/internal/usecase/app-serve-app.go
@@ -223,7 +223,8 @@ func (u *AppServeAppUsecase) GetAppServeAppById(ctx context.Context, appId strin
 				return asa, err
 			}
 			if len(applications) > 0 {
-				asa.GrafanaUrl = applications[0].Endpoint + "/d/tks_appserving_dashboard/tks-appserving-dashboard?refresh=30s&var-cluster=" + asa.TargetClusterId + "&var-kubernetes_namespace_name=" + asa.Namespace + "&var-kubernetes_pod_name=All&var-kubernetes_container_name=main&var-TopK=10"
+				// TODO: revert refresh param once the bug is resolved
+				asa.GrafanaUrl = applications[0].Endpoint + "/d/tks_appserving_dashboard/tks-appserving-dashboard?refresh=30s&var-cluster=" + asa.TargetClusterId + "&var-kubernetes_namespace_name=" + asa.Namespace + "&var-kubernetes_pod_name=All&var-kubernetes_container_name=main&var-TopK=10&refresh=30m"
 				log.Debugf(ctx, "Found grafanaURL: %s", asa.GrafanaUrl)
 			}
 		}


### PR DESCRIPTION
앱서빙 grafana 대시보드에서 refresh시 파라미터 정보가 유실되는 이슈가 있어, 우선 refresh 인터벌을 30m 으로 바꿔둡니다. 
내일 이벤트 이후, 근본적인 원인 해결이 필요합니다. 