### PR TITLE
trivial. add attribute to audit

### DIFF
--- a/internal/delivery/http/auth.go
+++ b/internal/delivery/http/auth.go
@@ -69,6 +69,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 			Description:    errorResponse.Text(),
 			ClientIP:       audit.GetClientIpAddress(w, r),
 			UserId:         nil,
+			UserAccountId:  input.AccountId,
 		})
 		log.Errorf(r.Context(), "error is :%s(%T)", err.Error(), err)
 		ErrorJSON(w, r, err)

--- a/internal/usecase/audit.go
+++ b/internal/usecase/audit.go
@@ -18,18 +18,27 @@ type IAuditUsecase interface {
 }
 
 type AuditUsecase struct {
-	repo     repository.IAuditRepository
-	userRepo repository.IUserRepository
+	repo             repository.IAuditRepository
+	userRepo         repository.IUserRepository
+	organizationRepo repository.IOrganizationRepository
 }
 
 func NewAuditUsecase(r repository.Repository) IAuditUsecase {
 	return &AuditUsecase{
-		repo:     r.Audit,
-		userRepo: r.User,
+		repo:             r.Audit,
+		userRepo:         r.User,
+		organizationRepo: r.Organization,
 	}
 }
 
 func (u *AuditUsecase) Create(ctx context.Context, dto model.Audit) (auditId uuid.UUID, err error) {
+	if dto.OrganizationId != "" {
+		organization, err := u.organizationRepo.Get(ctx, dto.OrganizationId)
+		if err == nil {
+			dto.OrganizationName = organization.Name
+		}
+	}
+
 	if dto.UserId != nil && *dto.UserId != uuid.Nil {
 		user, err := u.userRepo.GetByUuid(ctx, *dto.UserId)
 		if err != nil {


### PR DESCRIPTION
로그인 실패시 audit 메시지에 조직이름과 입력한 사용자 아이디 추가