### PR TITLE
파라미터를 명시하지 않은 정책을 적용할 때 버그 수정

### DIFF
--- a/internal/policy-template/policy-operator.go
+++ b/internal/policy-template/policy-operator.go
@@ -24,7 +24,7 @@ func PolicyToTksPolicyCR(policy *model.Policy) *TKSPolicy {
 		return nil
 	}
 
-	var params *apiextensionsv1.JSON = nil
+	var params *apiextensionsv1.JSON = &apiextensionsv1.JSON{Raw: []byte("{}")}
 
 	var jsonResult map[string]interface{}
 
@@ -86,6 +86,14 @@ func PolicyTemplateToTksPolicyTemplateCR(policyTemplate *model.PolicyTemplate) *
 	labels[PartOfKey] = PartOfVal
 	labels[TemplateIDLabel] = policyTemplate.ID.String()
 
+	var validation *Validation = nil
+
+	if len(policyTemplate.ParametersSchema) > 0 {
+		validation = &Validation{
+			OpenAPIV3Schema: ParamDefsToJSONSchemaProeprties(policyTemplate.ParametersSchema, false),
+		}
+	}
+
 	return &TKSPolicyTemplate{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tkspolicy.openinfradev.github.io/v1",
@@ -103,9 +111,7 @@ func PolicyTemplateToTksPolicyTemplateCR(policyTemplate *model.PolicyTemplate) *
 					Names: Names{
 						Kind: policyTemplate.Kind,
 					},
-					Validation: &Validation{
-						OpenAPIV3Schema: ParamDefsToJSONSchemaProeprties(policyTemplate.ParametersSchema, false),
-					},
+					Validation: validation,
 				},
 			},
 			Targets: []Target{{


### PR DESCRIPTION
아무 파라미터도 없는 정책 (예: block node port) 등을 처리할 때 Operator에서 nil dereference가 발생하는 버그 수정
