### PR TITLE
policy guard rule audit bugfix

### DIFF
--- a/internal/policy-template/tksguard-rego.go
+++ b/internal/policy-template/tksguard-rego.go
@@ -23,7 +23,7 @@ const tks_guard_rego_rulename = `  # Do not delete following line, added by TKS
 const tks_guard_rego_rulelogic = `
 # Do not delete or edit following rule, managed by TKS
 ___not_tks_triggered_request___ {
-  not input.review.userInfo
+  not input.review.userInfo.username
 } {
   tks_users := {"kubernetes-admin","system:serviceaccount:kube-system:argocd-manager"}
   tks_groups := {"system:masters"}


### PR DESCRIPTION
tks 계정인 경우 정책 검사를 스킵하는 guard rule이 audit을 스킵하는 버그 수정
- 기존은 audit 인 경우 input.review.userInfo가 undefined인 것으로 가정하고 작성하였으나 audit 인 경우 해당 값이 {} 임
- 따라서 input.review.userInfo가 undefined 인지 체크해야 하는 것이 아니라 input.review.userInfo.username이나
- input.review.userInfo.groups가 undefined 인지 체크가 필요함
- input.review.userInfo가 undefined 인지 체크하도록 수정하였음