### PR TITLE
정책 api match kind 타입 변경

### DIFF
--- a/internal/policy-template/kind-util.go
+++ b/internal/policy-template/kind-util.go
@@ -54,7 +54,7 @@ var KindToApiGroup = map[string]string{
 	"PodDisruptionBudget":            "policy",
 }
 
-func CheckAndNormalizeKinds(kinds []domain.Kinds) ([]domain.Kinds, error) {
+func CheckAndNormalizeKinds(kinds []string) ([]domain.Kinds, error) {
 	if kinds == nil {
 		return nil, nil
 	}
@@ -64,22 +64,20 @@ func CheckAndNormalizeKinds(kinds []domain.Kinds) ([]domain.Kinds, error) {
 	var normalizedMap = map[string]domain.Kinds{}
 
 	for _, kind := range kinds {
-		for _, kinditem := range kind.Kinds {
-			if apiGroup, ok := KindToApiGroup[kinditem]; ok {
-				if ai, ok := normalizedMap[apiGroup]; ok {
-					if !slices.Contains(ai.Kinds, kinditem) {
-						ai.Kinds = append(ai.Kinds, kinditem)
-						normalizedMap[apiGroup] = ai
-					}
-				} else {
-					normalizedMap[apiGroup] = domain.Kinds{
-						APIGroups: []string{apiGroup},
-						Kinds:     []string{kinditem},
-					}
+		if apiGroup, ok := KindToApiGroup[kind]; ok {
+			if ai, ok := normalizedMap[apiGroup]; ok {
+				if !slices.Contains(ai.Kinds, kind) {
+					ai.Kinds = append(ai.Kinds, kind)
+					normalizedMap[apiGroup] = ai
 				}
 			} else {
-				invalidKinds = append(invalidKinds, kinditem)
+				normalizedMap[apiGroup] = domain.Kinds{
+					APIGroups: []string{apiGroup},
+					Kinds:     []string{kind},
+				}
 			}
+		} else {
+			invalidKinds = append(invalidKinds, kind)
 		}
 	}
 

--- a/pkg/domain/policy.go
+++ b/pkg/domain/policy.go
@@ -5,15 +5,26 @@ import (
 	"time"
 )
 
+type Target struct {
+	Type  string `json:"type" enum:"simple,yaml"`
+	Value string `json:"value" example:"{\"kinds\":[\"Pod\",\"Deployment\"]}"`
+}
+
+type SimpleMatch struct {
+	Namespaces         []string `json:"namespaces,omitempty" validate:"matchnamespace"`
+	ExcludedNamespaces []string `json:"excludedNamespaces,omitempty" validate:"matchnamespace"`
+	Kinds              []string `json:"kinds,omitempty"`
+}
+
 type Kinds struct {
-	APIGroups []string `json:"apiGroups,omitempty"`
-	Kinds     []string `json:"kinds,omitempty"`
+	APIGroups []string `json:"apiGroups,omitempty" yaml:"apiGroups,omitempty"`
+	Kinds     []string `json:"kinds,omitempty" yaml:"kinds,omitempty"`
 }
 
 type Match struct {
-	Namespaces         []string `json:"namespaces,omitempty" validate:"matchnamespace"`
-	ExcludedNamespaces []string `json:"excludedNamespaces,omitempty" validate:"matchnamespace"`
-	Kinds              []Kinds  `json:"kinds,omitempty" validate:"matchkinds"`
+	Namespaces         []string `json:"namespaces,omitempty" yaml:"namespaces,omitempty" validate:"matchnamespace"`
+	ExcludedNamespaces []string `json:"excludedNamespaces,omitempty" yaml:"excludedNamespaces,omitempty" validate:"matchnamespace"`
+	Kinds              []Kinds  `json:"kinds,omitempty" yaml:"kinds,omitempty"`
 }
 
 func (m *Match) JSON() string {
@@ -45,8 +56,7 @@ type PolicyResponse struct {
 	EnforcementAction  string          `json:"enforcementAction" enum:"warn,deny,dryrun" example:"deny"`
 	Parameters         string          `json:"parameters" example:"{\"key\":\"value\"}"`
 	FilledParameters   []*ParameterDef `json:"filledParameters"`
-	Match              *Match          `json:"match,omitempty"`
-	MatchYaml          *string         `json:"matchYaml,omitempty" example:"namespaces:\r\n- testns1"`
+	Target             *Target         `json:"target,omitempty"`
 	//Tags              []string         `json:"tags,omitempty" example:"k8s,label"`
 }
 
@@ -60,8 +70,7 @@ type CreatePolicyRequest struct {
 	TemplateId         string  `json:"templateId" example:"d98ef5f1-4a68-4047-a446-2207787ce3ff"`
 	EnforcementAction  string  `json:"enforcementAction" validate:"required,oneof=deny dryrun warn" enum:"warn,deny,dryrun" example:"deny"`
 	Parameters         string  `json:"parameters" example:"{\"key\":\"value\"}"`
-	Match              *Match  `json:"match,omitempty"`
-	MatchYaml          *string `json:"matchYaml,omitempty" example:"namespaces:\r\n- testns1"`
+	Target             *Target `json:"target,omitempty"`
 	//Tags              []string         `json:"tags,omitempty" example:"k8s,label"`
 }
 
@@ -78,8 +87,7 @@ type UpdatePolicyRequest struct {
 	TemplateId        *string `json:"templateId,omitempty" example:"d98ef5f1-4a68-4047-a446-2207787ce3ff"`
 	EnforcementAction *string `json:"enforcementAction" validate:"omitempty,oneof=deny dryrun warn" enum:"warn,deny,dryrun" example:"deny"`
 	Parameters        *string `json:"parameters,omitempty" example:"{\"labels\":{\"key\":\"owner\",\"allowedRegex\":\"test*\"}"`
-	Match             *Match  `json:"match,omitempty"`
-	MatchYaml         *string `json:"matchYaml,omitempty"`
+	Target            *Target `json:"target,omitempty"`
 	//Tags              []string         `json:"tags,omitempty" example:"k8s,label"`
 }
 


### PR DESCRIPTION
# 개요
apiGroup이 다른 kind가 표시되지 않는 문제임
- 백엔드와 프론트엔드의 파라미터 처리 방식 불일치로 서로 apiGroup이 다른 리소스를 선택했을 경우 한 apiGroup만 표시되는 문제
- 프론트엔드에서는 kind만 지정하고 apiGroup은 백엔드에서 채워 주는데, 조회시 백엔드가 리턴한 apiGroup이 다르면 apiGroup 별로 분할해서 kind를 리턴함
- 프론트에서는 첫번째 kinds만 처리해서 그룹이 여러개인 경우 표시 안 됨

# 처리 방안
- 프론트에서 처리하는 Kinds를 flatten해서 ui에서 조회할 때에는 apiGroup을 제거하고 하나의 배열로 리턴
- 백엔드에서 저장하고 처리는 유지
- 관련 자료 구조를 다음 As-is 에서 To-be로 변경

## As-is
api에서 policies 조회 시 리턴하는 match는 향식은 다음과 같음.
```
"match": {
  "kinds": [
    {
      "apiGroups": [
        ""
      ],
      "kinds": [
        "Pod"
      ]
    }
  ]
}

또는

matchYaml : "...."
```

## To-be
- 형태에서 다음으로 변경 에정
- type에 따른 value 세팅으로 변경, value는 스트링 타입으로 json이나 yaml을 escape해서 보내야 함
- namespaces, exlucdeNamespaces는 ui에서 보내는 부분은 없지만 향후 사용할 여지가 있으므로 백엔드 기능은 살려 둠

```
"target": {
   "type": "simple" or "yaml", 
   "value": "...<yaml>.." or "{\"kinds\":[\"Pod\","\"Deployment\"],\"namespaces\":[\"ns1\"],\"excludeNamespaces\":[\"ns2\"]}"
}
```