### PR TITLE
템플릿 유형(kind) 검증 정규식 수정

### DIFF
--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -21,6 +21,7 @@ const (
 	REGEX_RFC1123_DNS_LABEL = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
 	REGEX_RESOURCE_NAME     = `^` + REGEX_RFC1123_DNS_LABEL + "$"
 	REGEX_RFC1123_SUBDOMAIN = `^` + REGEX_RFC1123_DNS_LABEL + `(\.` + REGEX_RFC1123_DNS_LABEL + `)*$`
+	REGEX_TEMPLATE_KIND     = `^[A-Z][a-zA-Z0-9]+$`
 )
 
 func NewValidator() (*validator.Validate, *ut.UniversalTranslator) {
@@ -42,6 +43,7 @@ func NewValidator() (*validator.Validate, *ut.UniversalTranslator) {
 	_ = v.RegisterValidation("resourcename", validateResourceName)
 	_ = v.RegisterValidation("matchnamespace", validateMatchNamespace)
 	_ = v.RegisterValidation("matchkinds", validateMatchKinds)
+	_ = v.RegisterValidation("templatekind", validateTemplateKind)
 
 	// register custom error
 	_ = v.RegisterTranslation("required", trans, func(ut ut.Translator) error {
@@ -123,6 +125,15 @@ func validateMatchKinds(fl validator.FieldLevel) bool {
 	}
 
 	return true
+}
+
+func validateTemplateKind(fl validator.FieldLevel) bool {
+	if fl.Field().String() == "" {
+		return false
+	}
+
+	r, _ := regexp.Compile(REGEX_TEMPLATE_KIND)
+	return r.MatchString(fl.Field().String())
 }
 
 func validateMatchKindAPIGroup(apigroups []string) bool {

--- a/pkg/domain/admin/policy-template.go
+++ b/pkg/domain/admin/policy-template.go
@@ -45,7 +45,7 @@ type SimplePolicyTemplateResponse struct {
 
 type CreatePolicyTemplateRequest struct {
 	TemplateName     string                 `json:"templateName" validate:"required,name" example:"필수 Label 검사"`
-	Kind             string                 `json:"kind" example:"K8sRequiredLabels" validate:"required,pascalcase"`
+	Kind             string                 `json:"kind" example:"K8sRequiredLabels" validate:"required,templatekind"`
 	Severity         string                 `json:"severity" validate:"required,oneof=low medium high" enums:"low,medium,high" example:"medium"`
 	Deprecated       bool                   `json:"deprecated" example:"false"`
 	Description      string                 `json:"description,omitempty"  example:"이 정책은 ..."`

--- a/pkg/domain/policy-template.go
+++ b/pkg/domain/policy-template.go
@@ -57,7 +57,7 @@ type SimplePolicyTemplateResponse struct {
 
 type CreatePolicyTemplateRequest struct {
 	TemplateName     string          `json:"templateName" validate:"required,name" example:"필수 Label 검사"`
-	Kind             string          `json:"kind" example:"K8sRequiredLabels" validate:"required,pascalcase"`
+	Kind             string          `json:"kind" example:"K8sRequiredLabels" validate:"required,templatekind"`
 	Severity         string          `json:"severity" validate:"required,oneof=low medium high" enums:"low,medium,high" example:"medium"`
 	Deprecated       bool            `json:"deprecated" example:"false"`
 	Description      string          `json:"description,omitempty"  example:"이 정책은 ..."`


### PR DESCRIPTION
단순 파스칼 케이스에서 K8sDisallowInteractiveTTY 등 실제 존재하는 다른 케이스도 통과하도록 정규식을 다음으로 수정

^[A-Z][a-zA-Z0-9]+$ 