### PR TITLE
템플릿, 템플릿 버전 저장 시 rego 문법 validation

### DIFF
--- a/internal/usecase/policy-template.go
+++ b/internal/usecase/policy-template.go
@@ -98,6 +98,10 @@ func (u *PolicyTemplateUsecase) Create(ctx context.Context, dto model.PolicyTemp
 
 	compileResult, err := u.RegoCompile(&domain.RegoCompileRequest{Rego: dto.Rego, Libs: dto.Libs}, false)
 
+	if err != nil {
+		return uuid.Nil, httpErrors.NewBadRequestError(fmt.Errorf("rego compile error"), "PT_INVALID_REGO_SYNTAX", "")
+	}
+
 	if len(compileResult.Errors) > 0 {
 		compileErrors := []string{}
 
@@ -556,6 +560,10 @@ func (u *PolicyTemplateUsecase) CreatePolicyTemplateVersion(ctx context.Context,
 	}
 
 	compileResult, err := u.RegoCompile(&domain.RegoCompileRequest{Rego: rego, Libs: libs}, false)
+
+	if err != nil {
+		return "", httpErrors.NewBadRequestError(fmt.Errorf("rego compile error"), "PT_INVALID_REGO_SYNTAX", "")
+	}
 
 	if len(compileResult.Errors) > 0 {
 		compileErrors := []string{}

--- a/internal/usecase/policy-template.go
+++ b/internal/usecase/policy-template.go
@@ -96,6 +96,20 @@ func (u *PolicyTemplateUsecase) Create(ctx context.Context, dto model.PolicyTemp
 		}
 	}
 
+	compileResult, err := u.RegoCompile(&domain.RegoCompileRequest{Rego: dto.Rego, Libs: dto.Libs}, false)
+
+	if len(compileResult.Errors) > 0 {
+		compileErrors := []string{}
+
+		for _, errorResult := range compileResult.Errors {
+			compileErrors = append(compileErrors, errorResult.Text)
+		}
+
+		detail := strings.Join(compileErrors, "\n")
+
+		return uuid.Nil, httpErrors.NewBadRequestError(fmt.Errorf("rego compile error"), "PT_INVALID_REGO_SYNTAX", detail)
+	}
+
 	if dto.IsTksTemplate() {
 		exists, err := u.repo.ExistByName(ctx, dto.TemplateName)
 		if err == nil && exists {
@@ -539,6 +553,20 @@ func (u *PolicyTemplateUsecase) CreatePolicyTemplateVersion(ctx context.Context,
 		if err == nil {
 			syncJson = &formatted
 		}
+	}
+
+	compileResult, err := u.RegoCompile(&domain.RegoCompileRequest{Rego: rego, Libs: libs}, false)
+
+	if len(compileResult.Errors) > 0 {
+		compileErrors := []string{}
+
+		for _, errorResult := range compileResult.Errors {
+			compileErrors = append(compileErrors, errorResult.Text)
+		}
+
+		detail := strings.Join(compileErrors, "\n")
+
+		return "", httpErrors.NewBadRequestError(fmt.Errorf("rego compile error"), "PT_INVALID_REGO_SYNTAX", detail)
 	}
 
 	if policyTemplate == nil {


### PR DESCRIPTION
템플릿, 템플릿 버전 저장 시 잘못된 Rego 코드가 저장되는 것을 방지하기 위해서 Rego 및 라이브러리 컴파일을 통한 validation 추가