### PR TITLE
trivial: increase num of log lines

### DIFF
--- a/internal/usecase/app-serve-app.go
+++ b/internal/usecase/app-serve-app.go
@@ -268,7 +268,9 @@ func (u *AppServeAppUsecase) GetAppServeAppLog(ctx context.Context, appId string
 	for _, pod := range pods.Items {
 		log.Debugf(ctx, "Processing pod: %s", pod.Name)
 
-		tailLines := int64(50)
+		// NOTE: show last 300 lines of app pod log.
+		// temporary workaround to show error log in case of the app pod crash
+		tailLines := int64(300)
 
 		req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
 			// name should be "tomcat" for legacy spring app


### PR DESCRIPTION
https://github.com/openinfradev/tks-api/pull/495 에서 도입한 로그 조회 API 에서 로그 라인 수를 50 -> 300 으로 변경합니다. 
(java stack trace 로그를 감안하여 최소 이정도는 필요할 것으로 예상합니다)